### PR TITLE
12: clauck fire forwards KEY=VALUE custom inputs to trigger-job.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to clauck are documented here. Format follows [Keep a Change
 
 ## [Unreleased]
 
-Nothing yet.
+### Added
+
+- **`clauck fire KEY=VALUE` custom inputs:** `clauck fire <name> [KEY=VALUE ...]` now forwards KEY=VALUE pairs to `trigger-job.sh`, which exports them as `CLAUCK_INPUT_*` env vars injected into the job's Runtime Context. Completes the v1.2.0 intent: the mechanism was implemented in `trigger-job.sh` and `run-job.sh` but the CLI entry point never exposed it. Non-KEY=VALUE extra args produce a warning and are dropped. See [#12](https://github.com/CoreyRDean/clauck/issues/12).
+- **SKILL.md: custom inputs documentation:** Added `### Pass custom inputs to a job` section documenting `KEY=VALUE` syntax for both `trigger-job.sh` (agents) and `clauck fire` (humans), with runtime context example and use-case guidance.
 
 ## [v1.3.0] — 2026-04-14
 

--- a/lib/clauck
+++ b/lib/clauck
@@ -4,7 +4,7 @@
 Usage:
     clauck list                          Show all jobs with status
     clauck status                        System overview
-    clauck fire <name>                   Ad-hoc trigger a job
+    clauck fire <name> [KEY=VALUE ...]   Ad-hoc trigger a job (with optional custom inputs)
     clauck pause <name>                  Disable a job
     clauck resume <name>                 Re-enable a paused job
     clauck edit <name>                   Open job prompt in your editor
@@ -197,10 +197,21 @@ def cmd_status() -> None:
             pass
 
 
-def cmd_fire(name: str) -> None:
+def cmd_fire(name: str, inputs: list[str] | None = None) -> None:
     if not TRIGGER_SCRIPT.exists():
         die("trigger-job.sh not found")
-    result = subprocess.run([str(TRIGGER_SCRIPT), name], capture_output=True, text=True)
+
+    kv_args: list[str] = []
+    for arg in (inputs or []):
+        if "=" in arg:
+            kv_args.append(arg)
+        else:
+            print(f"  warning: ignoring non-KEY=VALUE argument: {arg!r}", file=sys.stderr)
+
+    if kv_args:
+        print(f"  firing: {name} ({' '.join(kv_args)})")
+
+    result = subprocess.run([str(TRIGGER_SCRIPT), name] + kv_args, capture_output=True, text=True)
     print(result.stdout.strip())
     if result.returncode != 0:
         print(result.stderr.strip(), file=sys.stderr)
@@ -679,7 +690,7 @@ def main() -> None:
     elif cmd == "status":
         cmd_status()
     elif cmd == "fire" and rest:
-        cmd_fire(rest[0])
+        cmd_fire(rest[0], rest[1:] if len(rest) > 1 else None)
     elif cmd == "pause" and rest:
         cmd_pause(rest[0])
     elif cmd == "resume" and rest:

--- a/skill/clauck/SKILL.md
+++ b/skill/clauck/SKILL.md
@@ -103,7 +103,7 @@ The marketplace at `~/.claude/skills/clauck/marketplace/` ships curated job prom
 2. Show the user a compact summary of matching jobs with their `one_line`, `cost_per_run_usd_approx`, `requires.mcps`, and `schedule`.
 3. When the user picks one, **read the source `.md` file** and look for a `<!-- CUSTOMIZE BEFORE INSTALLING: -->` comment block. Walk the user through each customization (ask for the specific channel ID / path / etc.), and edit the copy in memory.
 4. Copy the customized content to `~/.claude/scheduled-jobs/<name>.md`. **Never overwrite an existing job of the same name without asking first.**
-5. Wait ~60s for the scheduler to pick up the new job (`.manifest.json` will regenerate), then ad-hoc fire it to verify: `~/.claude/scheduled-jobs/trigger-job.sh <name>`.
+5. Wait ~60s for the scheduler to pick up the new job (`.manifest.json` will regenerate), then ad-hoc fire it to verify: `~/.claude/scheduled-jobs/trigger-job.sh <name>` (or `clauck fire <name>` for human users).
 6. Tail the resulting log. If exit_code=0 and the expected side-effect happened (Slack post / file written / etc.), report success with the expected schedule and cost.
 7. If it failed, show the user the log excerpt and propose a fix.
 
@@ -406,7 +406,7 @@ One master LaunchAgent, N jobs. Adding a job is dropping a Markdown file.
 |---|---|
 | `~/.claude/scheduled-jobs/scheduler.py` | Discovery + dispatch. Runs every 60s. |
 | `~/.claude/scheduled-jobs/run-job.sh` | Per-job executor (log, preflight, compose runtime context, run claude). |
-| `~/.claude/scheduled-jobs/trigger-job.sh` | Ad-hoc-fire wrapper. Used by other agents that match a semantic hook. |
+| `~/.claude/scheduled-jobs/trigger-job.sh` | Ad-hoc-fire wrapper. Usage: `trigger-job.sh <name> [KEY=VALUE ...]`. KEY=VALUE pairs become `CLAUCK_INPUT_*` env vars in the job's runtime context. |
 | `~/.claude/scheduled-jobs/<name>.md` | A job: YAML frontmatter + prompt body. |
 | `~/.claude/scheduled-jobs-prompt.md` | Global system prompt appended to every job. |
 | `~/.claude/scheduled-jobs/.manifest.json` | Regenerated every tick. All jobs with their `cron`, `semantic_hooks`, and `trigger_command`. |
@@ -614,7 +614,7 @@ Delete the probe when done: `rm ~/.claude/scheduled-jobs/probe.md ~/.claude/sche
 
 1. Create `~/.claude/scheduled-jobs/<name>.md` with the frontmatter schema above and a prompt body describing exactly what this invocation should do.
 2. The scheduler regenerates the manifest within 60 seconds. No `launchctl reload` needed.
-3. Verify with `~/.claude/scheduled-jobs/trigger-job.sh <name>` before waiting for the first cron fire.
+3. Verify with `~/.claude/scheduled-jobs/trigger-job.sh <name>` (or `clauck fire <name>`) before waiting for the first cron fire. Pass `KEY=VALUE` args if the job needs custom inputs for this test run.
 
 **Prompt writing tips** for scheduled jobs (different from interactive prompts):
 
@@ -668,10 +668,36 @@ ls -t ~/.claude/scheduled-jobs/<name>-*.log | head -1 | xargs tail
 ### Ad-hoc fire a job
 
 ```bash
+# Basic fire (agents prefer this form):
 ~/.claude/scheduled-jobs/trigger-job.sh <name>
+
+# Human CLI equivalent (same result):
+clauck fire <name>
 ```
 
 Runtime Context will report `Trigger: adhoc` so the job can distinguish this from a cron fire.
+
+### Pass custom inputs to a job
+
+Any `KEY=VALUE` pairs after the job name are exported as `CLAUCK_INPUT_*` env vars and injected into the job's Runtime Context as a `## Custom inputs (passed via trigger)` section. The job's prompt can read them by name.
+
+```bash
+# Via trigger-job.sh (agents):
+~/.claude/scheduled-jobs/trigger-job.sh <name> FILE_PATH=/tmp/data.json MODE=strict
+
+# Via clauck CLI (humans):
+clauck fire <name> FILE_PATH=/tmp/data.json MODE=strict
+```
+
+Inside the job, the runtime context will contain:
+
+```
+## Custom inputs (passed via trigger)
+- **FILE_PATH:** /tmp/data.json
+- **MODE:** strict
+```
+
+Use this for parametric jobs that process different files or datasets on each trigger, for pipeline stages that receive routing decisions from upstream, or for debug overrides without editing the job file.
 
 ### Edit a job
 


### PR DESCRIPTION
## Why

v1.2.0 shipped custom input support end-to-end: `trigger-job.sh` exported `KEY=VALUE` args as `CLAUCK_INPUT_*` env vars, and `run-job.sh` injected them into the job's Runtime Context as a `## Custom inputs (passed via trigger)` section.

But `clauck fire` — the CLI entry point designed for human-facing job triggering — never forwarded those args to `trigger-job.sh`. Users who needed parametric job triggers had to bypass the CLI entirely and call `trigger-job.sh` directly: an undiscoverable path that breaks the "CLI is for humans, trigger-job.sh is for agents" contract the codebase signals.

This PR closes that gap. It completes the v1.2.0 intent without touching any logic outside the CLI dispatch layer.

Closes #12.

---

## What Changed

**`lib/clauck` — `cmd_fire()`**
- Accepts an optional `inputs: list[str]` argument
- Validates each extra arg contains `=`; warns to stderr and skips if not
- Echoes `firing: <name> (KEY=VALUE ...)` when inputs are present
- Forwards valid KEY=VALUE pairs to `trigger-job.sh` positional args

**`lib/clauck` — `main()`**
- `clauck fire <name>` passes `rest[1:]` to `cmd_fire` (existing `clauck fire <name>` with no extras is unchanged)

**`lib/clauck` — docstring**
- `clauck fire <name>` → `clauck fire <name> [KEY=VALUE ...]`

**`skill/clauck/SKILL.md`**
- New section: `### Pass custom inputs to a job` with paired examples (trigger-job.sh for agents, clauck fire for humans), runtime context sample output, and use-case guidance
- Path table entry for `trigger-job.sh` updated to show `KEY=VALUE` signature
- Two verification-step references updated to mention `clauck fire` as the human-equivalent

**`CHANGELOG.md`**
- `[Unreleased]` section populated with both changes

---

## Delta Report

| Dimension | Before | After |
|---|---|---|
| `clauck fire` exposes KEY=VALUE | No | Yes |
| Agents know KEY=VALUE syntax | trigger-job.sh usage only | Full section with CLI parity |
| Help text accurate | No | Yes |
| CHANGELOG reflects v1.2 intent | Partial | Complete |

The intent gap (KEY=VALUE mechanism exists but CLI doesn't expose it) is **closed**. The documentation gap (SKILL.md silent on custom inputs) is **closed**. No new concepts introduced — this is purely surface-area exposure of existing behaviour.

---

## Cost:Value

- **Cost:** ~50 LOC diff across 3 files. Zero new logic — pure forwarding.
- **Value:** Unblocks an entire class of parametric workflow patterns without requiring users to know about `trigger-job.sh`'s internals.
- **Risk:** None. Non-KEY=VALUE args warn and are dropped rather than silently passed; existing `clauck fire <name>` invocations are unaffected.

---

## Confidence:Impact

- **Confidence:** High. The implementation is trivially correct: validate, forward, existing path unchanged.
- **Impact:** Medium-high. Any user building pipelines with context-dependent stages benefits immediately. The SKILL.md update means agents will start suggesting this pattern.

---

## Reproduction Steps

1. Install clauck (or have it installed already)
2. Create a test job at `~/.claude/scheduled-jobs/test-echo.md` with a prompt that says "Print all Custom inputs from the Runtime Context"
3. Run: `clauck fire test-echo FRUIT=apple COLOR=red`
4. Expected CLI output: `  firing: test-echo (FRUIT=apple COLOR=red)`
5. Tail the resulting log; the agent's output should reference `FRUIT: apple` and `COLOR: red`
6. Verify: `clauck fire test-echo badarg` → warning `ignoring non-KEY=VALUE argument: 'badarg'` to stderr, job still fires normally

---

## Notes

This PR was created entirely unsupervised by an autonomous agent (`claude-sonnet-4-6` running via the clauck `clauck-intent-miner` scheduled job). It should remain **DRAFT** until peer reviewed by a human collaborator who can promote it out of draft. If WIP or changes are requested, please comment your intent to enable iteration by a future agent session.