### PR TITLE
[#10] fix: clauck edit supports module format and internal stage editing

### DIFF
--- a/lib/clauck
+++ b/lib/clauck
@@ -8,7 +8,8 @@ Usage:
     clauck fire <name>                   Ad-hoc trigger a job
     clauck pause <name>                  Disable a job
     clauck resume <name>                 Re-enable a paused job
-    clauck edit <name>                   Open job prompt in your editor
+    clauck edit <name>                   Open job prompt in your editor (flat or module)
+    clauck edit <module>/<stage>         Edit module internal stage file
     clauck remove <name>                 Delete a job + its state (also: delete, rm)
     clauck logs <name> [--last N]        Show recent logs
     clauck marketplace                    Browse pre-made jobs
@@ -496,10 +497,35 @@ def cmd_remove(name: str) -> None:
 
 
 def cmd_edit(name: str) -> None:
-    """Open job prompt in user's editor, validate on close."""
-    job_file = JOBS_DIR / f"{name}.md"
-    if not job_file.exists():
-        die(f"no job file: {job_file}")
+    """Open job prompt in user's editor, validate on close.
+
+    Supports both flat format (<name>.md) and module format (<name>/JOB.md).
+    For module internal stages, use: clauck edit <module>/<stage>
+    """
+    # Support <module>/<stage> for editing internal stage files
+    if "/" in name:
+        parts = name.split("/", 1)
+        module_name, stage = parts[0], parts[1]
+        stage_file = stage if stage.endswith(".md") else f"{stage}.md"
+        job_file = JOBS_DIR / module_name / stage_file
+        if not job_file.exists():
+            die(f"no stage file: {job_file}")
+    else:
+        # Flat format first, then module format
+        flat = JOBS_DIR / f"{name}.md"
+        module_entry = JOBS_DIR / name / "JOB.md"
+        if flat.exists():
+            job_file = flat
+        elif module_entry.exists():
+            job_file = module_entry
+            print(f"  (module job — editing entry point: {job_file.relative_to(JOBS_DIR)})")
+        else:
+            die(
+                f"no job found: {name}"
+                f"\n  checked: {flat}"
+                f"\n  checked: {module_entry}"
+                f"\n  tip: for module stage files use: clauck edit {name}/<stage>"
+            )
 
     # Determine editor: VISUAL > EDITOR > fallback
     editor = os.environ.get("VISUAL") or os.environ.get("EDITOR") or "nano"
@@ -532,12 +558,16 @@ def cmd_edit(name: str) -> None:
     # Validate required-ish fields
     fm_text = fm_match.group(1)
     issues = []
-    if "cron:" not in fm_text and "external_triggers:" not in fm_text:
-        issues.append("no cron or external_triggers — job will only fire via ad-hoc trigger")
-    if "max_budget_usd:" not in fm_text:
-        issues.append("no max_budget_usd — will use default ($2.00)")
-    if "model:" not in fm_text:
-        issues.append("no model specified — will use claude default (Opus)")
+
+    # Internal stage files use producers: instead of cron: — skip scheduling check
+    is_module_stage = job_file.name != "JOB.md" and job_file.parent != JOBS_DIR
+    if not is_module_stage:
+        if "cron:" not in fm_text and "external_triggers:" not in fm_text:
+            issues.append("no cron or external_triggers — job will only fire via ad-hoc trigger")
+        if "max_budget_usd:" not in fm_text:
+            issues.append("no max_budget_usd — will use default ($2.00)")
+        if "model:" not in fm_text:
+            issues.append("no model specified — will use claude default (Opus)")
 
     if issues:
         print("\033[33m  notes:\033[0m")
@@ -545,11 +575,13 @@ def cmd_edit(name: str) -> None:
             print(f"    - {issue}")
     else:
         print("  \033[32m✓\033[0m saved, looks good. Changes take effect within 60s.")
-    # Also reset runs-remaining if max_runs was exhausted
-    rr = STATE_DIR / f"{name}.runs-remaining"
+
+    # Reset runs-remaining on the canonical job name (not stage path)
+    canonical_name = name.split("/")[0] if "/" in name else name
+    rr = STATE_DIR / f"{canonical_name}.runs-remaining"
     if rr.exists():
         rr.unlink()
-        print(f"  reset runs counter for: {name}")
+        print(f"  reset runs counter for: {canonical_name}")
 
 
 def cmd_logs(name: str, last: int = 5) -> None:


### PR DESCRIPTION
## Why

Closes #10.

`clauck edit <name>` silently died with `error: no job file: ...` when the job used the module format (`<name>/JOB.md`). The command only probed for `<name>.md`, so any module job was completely unreachable via the CLI's edit flow. This blocked editing module jobs without knowing the underlying path and opening files manually.

## What changed

**`lib/clauck` — `cmd_edit`**

- **Module format support:** `clauck edit <name>` now resolves to `<name>/JOB.md` when no flat `<name>.md` exists. Prints a one-line hint confirming which file was resolved.
- **Stage editing:** `clauck edit <module>/<stage>` opens the named internal stage file (`.md` suffix is optional). Covers the case where a developer wants to iterate on a specific pipeline stage.
- **Format-aware validation:** Internal stage files (`producers:`-driven, no `cron:`) skip the cron/budget/model warning checks — those only apply to entry-point files.
- **Correct state reset:** The runs-remaining reset uses the canonical job name (`module`), not the raw `module/stage` argument.
- **Better error message:** When neither flat nor module format resolves, the error now lists both checked paths and hints at the stage editing syntax.

## Delta report

| Before | After |
|---|---|
| `clauck edit intent-miner` → `error: no job file` (module job) | Resolves to `intent-miner/JOB.md` and opens it |
| No way to edit internal stages via CLI | `clauck edit intent-miner/stage-1` works |
| Validation warns "no cron" on stage files (invalid check) | Stage files skip scheduling checks |
| State reset used raw `module/stage` path as key | Uses canonical job name |

## Cost:value

- **Change size:** 46 insertions, 14 deletions — one function in one file.
- **Risk:** Low. Resolution order (flat-first) preserves all existing behavior; module path only activates when flat doesn't exist.
- **Value:** High. Module format is the preferred structure for complex jobs (introduced in v1.3.0). Without this fix, editing a module job via `clauck edit` is broken for all users.

## Reproduction directive

```bash
# Setup: create a module-format job
mkdir -p ~/.claude/scheduled-jobs/test-module
cat > ~/.claude/scheduled-jobs/test-module/JOB.md <<'MD'
---
cron: "0 * * * *"
max_budget_usd: 0.50
model: haiku
---
Test module entry point.
MD

# Before fix: dies immediately
# clauck edit test-module → error: no job file: .../test-module.md

# After fix: resolves and informs
# clauck edit test-module → "(module job — editing entry point: test-module/JOB.md)"
# (opens JOB.md in $EDITOR)

# Also: internal stage editing
# clauck edit test-module/JOB  →  opens test-module/JOB.md directly
```

**Confidence:** High — the resolution logic mirrors the already-working `cmd_remove` pattern (lines 321–324). All CLAUDE.md checks pass: bash -n, Python AST, JSON parse, install dry-run.