### PR TITLE
[#4] feat: macOS push notifications for job completions

### DIFF
--- a/lib/clauck
+++ b/lib/clauck
@@ -19,6 +19,7 @@ Usage:
     clauck update [--apply]              Check for / apply updates
     clauck uninstall [--wipe]            Uninstall (preserves jobs/logs unless --wipe)
     clauck config [set <key> <value>]    Show or edit config
+                                         (e.g. clauck config set notifications true)
     clauck add <path> [--name N] [--when "schedule"]  Import a file as a job
     clauck inspect <name>                 Inspect a job's config and DAG
     clauck doctor [--fix] [--unsafe] [-i] [<context>]   Diagnose system health
@@ -342,6 +343,8 @@ def cmd_status() -> None:
     print(f"  repo: {repo}")
     print(f"  auto-update: {'enabled' if auto_update.get('enabled', True) else 'disabled'}"
           f" (auto-apply: {'on' if auto_update.get('auto_apply', False) else 'off'})")
+    notif = config.get("notifications", False)
+    print(f"  notifications: {'on' if notif else 'off'} (toggle: clauck config set notifications true/false)")
 
     # Check for pending update
     available = STATE_DIR / ".update-available"

--- a/lib/run-job.sh
+++ b/lib/run-job.sh
@@ -458,4 +458,49 @@ if [ "${CLAUDE_JOB_INTERACTIVE:-}" = "1" ] && [ "$EXIT_CODE" -eq 0 ]; then
 fi
 
 echo "--- exit_code=$EXIT_CODE ===" >> "$LOG_FILE"
+
+# --- macOS push notification (opt-in via: clauck config set notifications true) ---
+/usr/bin/python3 - "${JOB_NAME}" "${EXIT_CODE}" "${LOG_FILE}" "${JOBS_DIR}/.clauck.config.json" << 'PYEOF' 2>/dev/null || true
+import json, os, subprocess, sys
+
+job_name = sys.argv[1] if len(sys.argv) > 1 else "?"
+try:
+    exit_code = int(sys.argv[2])
+except (IndexError, ValueError):
+    exit_code = 0
+log_file = sys.argv[3] if len(sys.argv) > 3 else ""
+cfg_path = sys.argv[4] if len(sys.argv) > 4 else ""
+
+try:
+    cfg = json.load(open(cfg_path))
+    if not cfg.get("notifications", False):
+        sys.exit(0)
+except Exception:
+    sys.exit(0)
+
+cost = ""
+try:
+    for line in reversed(open(log_file).read().splitlines()):
+        try:
+            obj = json.loads(line)
+            c = obj.get("total_cost_usd") or obj.get("cost_usd")
+            if c is not None:
+                cost = f"${float(c):.4f}"
+                break
+        except Exception:
+            pass
+except Exception:
+    pass
+
+if exit_code == 0:
+    body = f"completed ({cost})" if cost else "completed"
+else:
+    body = f"failed (exit {exit_code})"
+
+safe_name = job_name.replace("\\", "\\\\").replace('"', '\\"')
+safe_body = body.replace("\\", "\\\\").replace('"', '\\"')
+script = f'display notification "{safe_body}" with title "clauck: {safe_name}"'
+subprocess.run(["osascript", "-e", script], capture_output=True, timeout=5)
+PYEOF
+
 exit $EXIT_CODE

--- a/skill/clauck/SKILL.md
+++ b/skill/clauck/SKILL.md
@@ -177,6 +177,18 @@ Append to `$CLAUCK_OUTPUT_DIR/my-feed.md` (the **Output directory** in your Runt
 
 `.state/` is still appropriate for internal artifacts the user doesn't need to read directly (lock files, producer outputs, trigger state).
 
+## Push notifications
+
+clauck can send a macOS native push notification when each job completes. Disabled by default.
+
+**Enable:** `clauck config set notifications true`
+**Disable:** `clauck config set notifications false`
+**Check status:** `clauck status` (shows "notifications: on/off")
+
+Each notification shows the job name, success/failure, and cost if available — e.g. *"completed ($0.0312)"* or *"failed (exit 1)"*.
+
+The notification fires after the claude session exits, regardless of success or failure. It is emitted via `osascript` and requires no additional software. Silent (no banner) if the user has disabled notifications for Terminal in macOS System Settings → Notifications.
+
 ## Auto-update configuration
 
 Config file: `~/.clauck/.clauck.config.json`


### PR DESCRIPTION
## Closes #4

## Why

Users who run jobs on a schedule have no visibility into when jobs complete unless they actively check logs. A subtle, opt-in macOS notification closes this loop — you know your morning-brief ran, what it cost, and whether it succeeded, without polling.

## What changed

**`lib/run-job.sh`** — Adds a notification block after the claude session exits. Reads `notifications` from `.clauck.config.json`; if enabled, extracts `total_cost_usd` from the JSON output envelope in the log and fires an `osascript` notification. Safe string escaping is handled in Python to prevent AppleScript injection from job names or cost strings.

**`lib/clauck`** — `clauck status` now shows `notifications: on/off` and the toggle command. Usage docstring updated to surface `clauck config set notifications true/false` as an example.

**`skill/clauck/SKILL.md`** — New "Push notifications" section documenting enablement, behavior, and the macOS Notifications System Settings caveat.

## Delta report

| Before | After |
|---|---|
| No indication when a job completes | Native macOS notification fires on completion |
| Must check `clauck logs <name>` to see if a job ran | Notification shows success/failure + cost |
| Issue #4 open since v1.2.0 deferral | Closed |

**Default:** `notifications: false` — zero behavior change for existing installs.

## Cost:value

Implementation cost: ~45 lines of Python inside a zsh heredoc + 3 lines of CLI changes. No new dependencies (`osascript` is macOS built-in). Zero overhead when disabled (single JSON read + early exit).

**Confidence:impact:** High confidence (osascript notifications are well-understood, the JSON envelope field `total_cost_usd` is already parsed in dag-runner.py using the same pattern). High impact for users running multiple scheduled jobs who want passive awareness.

## Reproduction

```bash
# After applying this branch:
clauck config set notifications true
clauck fire heartbeat
# → should see a macOS notification: "clauck: heartbeat — completed ($0.00XX)"

clauck config set notifications false
clauck fire heartbeat
# → no notification (default behavior preserved)

clauck status
# → should show: "notifications: on/off (toggle: clauck config set notifications true/false)"
```

## Note on rebase

Branch was rebased onto current main (was based at `abbb7fc`, 5 commits behind). The original commit included path migration changes already merged at `7fad898`. After rebase those are gone — diff now contains only the notification feature: 45 lines in run-job.sh, 3 lines in clauck, 12 lines in SKILL.md.