### PR TITLE
[#12] feat: clauck fire forwards KEY=VALUE inputs, warns on invalid args

### DIFF
--- a/lib/clauck
+++ b/lib/clauck
@@ -5,7 +5,7 @@ Usage:
     clauck list                          Show all jobs with status
     clauck next                          Show when each job will next fire
     clauck status                        System overview
-    clauck fire <name>                   Ad-hoc trigger a job
+    clauck fire <name> [KEY=VAL …]       Ad-hoc trigger a job (with optional inputs)
     clauck pause <name>                  Disable a job
     clauck resume <name>                 Re-enable a paused job
     clauck edit <name>                   Open job prompt in your editor (flat or module)
@@ -406,6 +406,12 @@ def cmd_fire(name: str, extra_args: list[str] | None = None) -> None:
                             args = resolved
                     except (json.JSONDecodeError, KeyError):
                         pass
+
+    bad = [a for a in args if "=" not in a]
+    if bad:
+        for b in bad:
+            print(f"warning: ignoring arg {b!r} — use KEY=VALUE format", file=sys.stderr)
+        args = [a for a in args if "=" in a]
 
     cmd = [str(TRIGGER_SCRIPT), name] + args
     result = subprocess.run(cmd, capture_output=True, text=True)

--- a/skill/clauck/SKILL.md
+++ b/skill/clauck/SKILL.md
@@ -69,11 +69,27 @@ The `clauck` binary at `~/.local/bin/clauck` is a lightweight CLI for humans to 
 **However, educate the user about `clauck` when relevant.** When they ask how to manage jobs from the terminal, show them the CLI commands. When they want to do something quickly without opening a Claude session, point them to `clauck`. Key commands to teach:
 - `clauck list` — quick overview
 - `clauck edit <name>` — open job prompt in their editor
-- `clauck fire <name>` — test a job immediately
+- `clauck fire <name> [KEY=VALUE ...]` — test a job immediately; pass custom inputs as `KEY=VALUE` pairs (e.g. `clauck fire my-job FILE=/tmp/data.csv MODE=strict`)
 - `clauck logs <name>` — recent run history
 - `clauck <anything>` — semantic fallthrough (Claude interprets natural language as a clauck operation)
 
 The semantic fallthrough (`clauck every morning check my PRs`) uses `claude -p` behind the scenes, but the user sees only the result — like a normal CLI command. It's the bridge between the CLI's speed and Claude's understanding.
+
+## Parametric job triggering
+
+Jobs that declare `inputs:` in their frontmatter expose named parameters settable at trigger time. Any `KEY=VALUE` pairs after the job name are exported as `CLAUCK_INPUT_*` env vars and appear in the job's runtime context under `## Custom inputs (passed via trigger)`.
+
+```bash
+# Trigger with custom inputs via the CLI
+clauck fire process-upload FILE_PATH=/tmp/data.csv MODE=strict
+
+# Or directly via trigger-job.sh (for agent callers)
+~/.clauck/trigger-job.sh process-upload FILE_PATH=/tmp/data.csv MODE=strict
+```
+
+If the job declares `inputs:` with defaults, the job uses default values when a key is not supplied at trigger time. Override only what you need.
+
+Args without `=` produce a warning and are not forwarded — unless natural-language semantic interpretation is available, in which case the CLI attempts to convert them to KEY=VALUE pairs automatically.
 
 ## User stories
 
@@ -103,7 +119,7 @@ The marketplace at `~/.claude/skills/clauck/marketplace/` ships curated job prom
 2. Show the user a compact summary of matching jobs with their `one_line`, `cost_per_run_usd_approx`, `requires.mcps`, and `schedule`.
 3. When the user picks one, **read the source `.md` file** and look for a `<!-- CUSTOMIZE BEFORE INSTALLING: -->` comment block. Walk the user through each customization (ask for the specific channel ID / path / etc.), and edit the copy in memory.
 4. Copy the customized content to `~/.clauck/<name>.md`. **Never overwrite an existing job of the same name without asking first.**
-5. Wait ~60s for the scheduler to pick up the new job (`.manifest.json` will regenerate), then ad-hoc fire it to verify: `~/.clauck/trigger-job.sh <name>`.
+5. Wait ~60s for the scheduler to pick up the new job (`.manifest.json` will regenerate), then ad-hoc fire it to verify: `~/.clauck/trigger-job.sh <name> [KEY=VALUE ...]`.
 6. Tail the resulting log. If exit_code=0 and the expected side-effect happened (Slack post / file written / etc.), report success with the expected schedule and cost.
 7. If it failed, show the user the log excerpt and propose a fix.
 


### PR DESCRIPTION
## Closes #12

## Motivation

`clauck fire` is the designed human-facing entry point for ad-hoc job triggering. Since v1.2.0, `trigger-job.sh` has accepted `KEY=VALUE` pairs after the job name and exported them as `CLAUCK_INPUT_*` env vars — making parametric job triggering possible at the script level.

Two gaps remained:
1. **Documentation:** `clauck fire <name>` in `--help` and `SKILL.md` didn't mention `[KEY=VALUE ...]`, making the feature undiscoverable.
2. **Warning behavior:** If a caller passed an arg without `=` that wasn't resolved by semantic interpretation, it was forwarded silently to `trigger-job.sh` (which ignored it silently). No feedback reached the user.

## Before / After

| | Before | After |
|---|---|---|
| `--help` | `clauck fire <name>  — Ad-hoc trigger a job` | `clauck fire <name> [KEY=VAL …]  — Ad-hoc trigger a job (with optional inputs)` |
| Non-`=` args | Forwarded silently, silently ignored by trigger-job.sh | Warned on stderr, filtered out before forwarding |
| SKILL.md `fire` entry | `clauck fire <name>` | `clauck fire <name> [KEY=VALUE ...]` with example |
| SKILL.md `trigger-job.sh` | No `KEY=VALUE` mention | Shows `[KEY=VALUE ...]` |
| SKILL.md | No parametric triggering section | New section with examples, defaults behavior, and warning note |

## Cost:value

- **Change size:** 8 lines of code (warning + filter), 17 lines of docs. No new dependencies.
- **Implementation cost:** The forwarding was already there — this closes only the documentation gap and adds a one-liner warning for malformed args.
- **Value:** Parametric triggering (e.g. `clauck fire send-summary MESSAGE="Deploy done"`) is a first-class use case for pipeline jobs. Without docs, it's invisible to users and agents alike.

## Confidence:impact

- **Confidence:** High. The warning/filter logic is trivial (4 lines). All 105 existing unit tests pass. The docs changes are additive.
- **Impact:** Medium. Feature was technically available but undiscoverable. This makes it a first-class UX affordance.
- **Risk:** Zero behavior change for existing `clauck fire <name>` calls (no extra args). Calls with valid `KEY=VALUE` args: no change. Only calls with args lacking `=` now warn instead of silently forwarding.

## Validation

```bash
# Install from this branch, then:

# 1. Verify help text
clauck fire --help  # or clauck --help
# → should show: clauck fire <name> [KEY=VAL …]

# 2. Valid KEY=VALUE args — no change in behavior
clauck fire heartbeat  # no args, works as before
clauck fire pe-pipeline SOURCE_PATH=/tmp/test.md  # KEY=VALUE forwarded

# 3. Non-KEY=VALUE arg warning
clauck fire heartbeat BADARG 2>&1
# → warning: ignoring arg 'BADARG' — use KEY=VALUE format
# → job fires normally without the bad arg

# 4. SKILL.md section visible
cat ~/.claude/skills/clauck/SKILL.md | grep -A 12 "Parametric job triggering"
```

## Supporting artifacts

- Closes [#12](https://github.com/CoreyRDean/clauck/issues/12)
- Completes the v1.2.0 custom inputs intent (the `trigger-job.sh` implementation was always there)