### PR TITLE
[#9] feat: marketplace jobs demonstrating session_persist, temporal scheduling, and pipelines

### DIFF
--- a/marketplace/index.json
+++ b/marketplace/index.json
@@ -1,5 +1,5 @@
 {
-  "version": "v0.1.2",
+  "version": "v0.1.4",
   "description": "Curated pre-made scheduled-job prompts for clauck. Browse by category or tags; ask Claude to copy one into your scheduled-jobs directory to install.",
   "jobs": [
     {
@@ -7,12 +7,20 @@
       "version": "1.0.0",
       "path": "morning-brief.md",
       "category": "productivity",
-      "tags": ["productivity", "digest", "daily", "slack", "calendar", "jira", "standup"],
+      "tags": [
+        "productivity",
+        "digest",
+        "daily",
+        "slack",
+        "calendar",
+        "jira",
+        "standup"
+      ],
       "one_line": "Weekday morning digest: unread Slack mentions, today's calendar, and open Jira tickets in one post.",
       "schedule": "weekdays at 13:00 UTC (configurable)",
-      "cost_per_run_usd_approx": 0.20,
+      "cost_per_run_usd_approx": 0.2,
       "runs_per_month_approx": 22,
-      "monthly_cost_usd_approx": 4.40,
+      "monthly_cost_usd_approx": 4.4,
       "requires": {
         "mcps": "Slack + Google Calendar + Atlassian (any subset works; missing sections are skipped)",
         "setup": [
@@ -26,7 +34,14 @@
       "version": "1.0.0",
       "path": "github-pr-digest.md",
       "category": "productivity",
-      "tags": ["productivity", "github", "pull-requests", "digest", "daily", "code-review"],
+      "tags": [
+        "productivity",
+        "github",
+        "pull-requests",
+        "digest",
+        "daily",
+        "code-review"
+      ],
       "one_line": "Weekday digest of PRs needing your attention: reviews requested, stale drafts, recently merged.",
       "schedule": "weekdays at 14:00 UTC (configurable)",
       "cost_per_run_usd_approx": 0.12,
@@ -44,7 +59,14 @@
       "version": "1.0.0",
       "path": "inbox-zero-assist.md",
       "category": "productivity",
-      "tags": ["productivity", "gmail", "email", "triage", "inbox-zero", "daily"],
+      "tags": [
+        "productivity",
+        "gmail",
+        "email",
+        "triage",
+        "inbox-zero",
+        "daily"
+      ],
       "one_line": "End-of-day scan of Gmail threads unread for 48h+. Suggests actions in a local file. Never sends.",
       "schedule": "weekdays at 22:00 UTC (configurable)",
       "cost_per_run_usd_approx": 0.12,
@@ -63,12 +85,18 @@
       "version": "1.0.0",
       "path": "daily-verify.md",
       "category": "verification",
-      "tags": ["verification", "health-check", "daily", "mcp", "notification"],
+      "tags": [
+        "verification",
+        "health-check",
+        "daily",
+        "mcp",
+        "notification"
+      ],
       "one_line": "Daily MCP-surface health check posted to your choice of Slack/Discord/Jira/Gmail/local file.",
       "schedule": "daily at 14:00 UTC (configurable)",
-      "cost_per_run_usd_approx": 0.20,
+      "cost_per_run_usd_approx": 0.2,
       "runs_per_month_approx": 30,
-      "monthly_cost_usd_approx": 6.00,
+      "monthly_cost_usd_approx": 6.0,
       "requires": {
         "mcps": "at least one of: Slack, Discord, Jira, Gmail (OR none in local-file mode)",
         "setup": [
@@ -81,7 +109,13 @@
       "version": "1.0.0",
       "path": "downloads-triage.md",
       "category": "organization",
-      "tags": ["organization", "file-watcher", "downloads", "triage", "external-trigger"],
+      "tags": [
+        "organization",
+        "file-watcher",
+        "downloads",
+        "triage",
+        "external-trigger"
+      ],
       "one_line": "Fires when new files land in ~/Downloads. Categorizes and suggests destinations.",
       "schedule": "event-driven (file_added trigger, 60s quiet period, 5min debounce)",
       "cost_per_run_usd_approx": 0.04,
@@ -97,7 +131,14 @@
       "version": "1.0.0",
       "path": "workspace-cleanup.md",
       "category": "organization",
-      "tags": ["organization", "desktop", "files", "cleanup", "stale", "weekly"],
+      "tags": [
+        "organization",
+        "desktop",
+        "files",
+        "cleanup",
+        "stale",
+        "weekly"
+      ],
       "one_line": "Weekly scan of Desktop and Documents for stale files, generic names, and large files. Report only.",
       "schedule": "Sundays at 17:00 UTC",
       "cost_per_run_usd_approx": 0.04,
@@ -113,12 +154,16 @@
       "version": "1.0.0",
       "path": "module-demo/",
       "category": "example",
-      "tags": ["example", "module", "reference"],
+      "tags": [
+        "example",
+        "module",
+        "reference"
+      ],
       "one_line": "Reference module-format marketplace job. Demonstrates the <name>/JOB.md directory shape for multi-file jobs.",
       "schedule": "ad-hoc only",
       "cost_per_run_usd_approx": 0.01,
       "runs_per_month_approx": 0,
-      "monthly_cost_usd_approx": 0.00,
+      "monthly_cost_usd_approx": 0.0,
       "requires": {
         "mcps": "none",
         "setup": [
@@ -132,7 +177,15 @@
       "version": "1.0.0",
       "path": "event-monitor.md",
       "category": "monitoring",
-      "tags": ["monitoring", "health-check", "temporary", "on-call", "deployment", "event", "time-bounded"],
+      "tags": [
+        "monitoring",
+        "health-check",
+        "temporary",
+        "on-call",
+        "deployment",
+        "event",
+        "time-bounded"
+      ],
       "one_line": "Time-bounded health checker: runs every 15 min inside a custom window, alerts on failure, auto-expires when done.",
       "schedule": "every 15 min within a configurable time window (auto-expires)",
       "cost_per_run_usd_approx": 0.04,
@@ -142,7 +195,7 @@
         "mcps": "none (local file fallback) or Slack (for push alerts)",
         "setup": [
           "Set valid_after to your window start (ISO 8601).",
-          "Set expires_after to your window end — job auto-disables when it passes.",
+          "Set expires_after to your window end \u2014 job auto-disables when it passes.",
           "Set HEALTH_URL input default to your endpoint.",
           "Optionally set ALERT_CHANNEL to a Slack DM or channel ID."
         ]
@@ -153,12 +206,19 @@
       "version": "1.0.0",
       "path": "git-commit-nudge.md",
       "category": "monitoring",
-      "tags": ["monitoring", "git", "uncommitted", "unpushed", "nudge", "developer"],
+      "tags": [
+        "monitoring",
+        "git",
+        "uncommitted",
+        "unpushed",
+        "nudge",
+        "developer"
+      ],
       "one_line": "Every 4 hours, check repos for uncommitted changes or unpushed commits. Nudge via local file.",
       "schedule": "every 4 hours",
       "cost_per_run_usd_approx": 0.04,
       "runs_per_month_approx": 180,
-      "monthly_cost_usd_approx": 7.20,
+      "monthly_cost_usd_approx": 7.2,
       "requires": {
         "mcps": "none",
         "setup": [
@@ -171,12 +231,17 @@
       "version": "1.0.0",
       "path": "dynamic-context-demo.md",
       "category": "example",
-      "tags": ["example", "templating", "demo", "reference"],
-      "one_line": "Reference job demonstrating {{cmd:}} inline bash templating — injects live date and git state into the prompt body.",
+      "tags": [
+        "example",
+        "templating",
+        "demo",
+        "reference"
+      ],
+      "one_line": "Reference job demonstrating {{cmd:}} inline bash templating \u2014 injects live date and git state into the prompt body.",
       "schedule": "ad-hoc only (customize cron to taste)",
       "cost_per_run_usd_approx": 0.01,
       "runs_per_month_approx": 0,
-      "monthly_cost_usd_approx": 0.00,
+      "monthly_cost_usd_approx": 0.0,
       "requires": {
         "mcps": "none",
         "setup": [
@@ -202,6 +267,105 @@
           "Set name: to something unique, e.g. gh-watch-123",
           "Set ISSUE_URL default to the GitHub issue URL to watch.",
           "Optionally set NOTIFY_CHANNEL to a Slack DM channel ID for push notifications."
+        ]
+      }
+    },
+    {
+      "name": "work-journal",
+      "path": "work-journal.md",
+      "category": "productivity",
+      "tags": [
+        "productivity",
+        "journal",
+        "developer",
+        "session-persist"
+      ],
+      "one_line": "Weekday end-of-day work journal from git activity \u2014 accumulates context across runs to surface patterns.",
+      "schedule": "weekdays at 22:00 UTC (configurable)",
+      "cost_per_run_usd_approx": 0.04,
+      "runs_per_month_approx": 22,
+      "monthly_cost_usd_approx": 0.88,
+      "feature_demo": "session_persist",
+      "requires": {
+        "mcps": "none",
+        "setup": [
+          "Set REPOS_ROOT to your git repos parent directory.",
+          "Optionally change OUTPUT_FILE path."
+        ]
+      }
+    },
+    {
+      "name": "release-monitor",
+      "path": "release-monitor.md",
+      "category": "monitoring",
+      "tags": [
+        "monitoring",
+        "github",
+        "temporal",
+        "release",
+        "bounded"
+      ],
+      "one_line": "Bounded post-release watcher \u2014 monitors a GitHub repo for new issues during a release window, then auto-disables.",
+      "schedule": "every 6 hours (configurable), bounded by valid_after + expires_after",
+      "cost_per_run_usd_approx": 0.12,
+      "runs_per_month_approx": "28 max (1 week)",
+      "monthly_cost_usd_approx": "~$3.36 max (auto-disables after window)",
+      "feature_demo": "valid_after + expires_after + max_runs",
+      "requires": {
+        "mcps": "none (uses gh CLI)",
+        "setup": [
+          "Set REPO to owner/repo format.",
+          "Set valid_after to your release date (YYYY-MM-DD).",
+          "Set expires_after to 7 days after release (YYYY-MM-DD)."
+        ]
+      }
+    },
+    {
+      "name": "standup-gather",
+      "path": "standup-gather.md",
+      "category": "developer",
+      "tags": [
+        "developer",
+        "pipeline",
+        "standup",
+        "pipeline-stage"
+      ],
+      "one_line": "Pipeline stage \u2014 collects git commits from the last 24h. Consumed by the standup job.",
+      "schedule": "ad-hoc only (pipeline stage; fired by standup job)",
+      "cost_per_run_usd_approx": 0.04,
+      "runs_per_month_approx": 22,
+      "monthly_cost_usd_approx": 0.88,
+      "feature_demo": "producers/consumers (pipeline stage)",
+      "requires": {
+        "mcps": "none",
+        "setup": [
+          "Set REPOS_ROOT to your git repos parent directory.",
+          "Install alongside standup.md \u2014 these two jobs form a pipeline."
+        ]
+      }
+    },
+    {
+      "name": "standup",
+      "path": "standup.md",
+      "category": "productivity",
+      "tags": [
+        "productivity",
+        "developer",
+        "pipeline",
+        "standup"
+      ],
+      "one_line": "Weekday standup generator \u2014 pulls git activity via the standup-gather pipeline and writes a formatted standup note.",
+      "schedule": "weekdays at 13:00 UTC (configurable)",
+      "cost_per_run_usd_approx": 0.08,
+      "runs_per_month_approx": 22,
+      "monthly_cost_usd_approx": 1.76,
+      "feature_demo": "producers/consumers (pipeline root)",
+      "requires": {
+        "mcps": "none",
+        "setup": [
+          "Install alongside standup-gather.md \u2014 these two jobs form a pipeline.",
+          "Set REPOS_ROOT in standup-gather.md.",
+          "Optionally change OUTPUT_FILE path."
         ]
       }
     }

--- a/marketplace/release-monitor.md
+++ b/marketplace/release-monitor.md
@@ -1,0 +1,64 @@
+---
+name: release-monitor
+description: Bounded post-release monitor — watches a GitHub repo for new issues during a release window, then auto-disables.
+cron: "0 */6 * * *"
+max_turns: 6
+max_budget_usd: 0.12
+cwd: ~
+effort: low
+model: haiku
+valid_after: "TODO: YYYY-MM-DD"
+expires_after: "TODO: YYYY-MM-DD"
+max_runs: 28
+tags:
+  - monitoring
+  - github
+  - temporal
+  - release
+  - bounded
+semantic_hooks:
+  - Monitor GitHub issues after a release or launch
+  - Watch for problems during the first week after shipping
+  - Temporary bounded monitoring job
+---
+
+<!--
+CUSTOMIZE BEFORE INSTALLING:
+1. Set REPO to the GitHub repo to monitor (owner/repo format).
+   Example: REPO=CoreyRDean/clauck
+2. Set valid_after to your release date (YYYY-MM-DD).
+3. Set expires_after to 7 days after release (YYYY-MM-DD).
+4. Adjust OUTPUT_FILE path if desired.
+5. max_runs=28 = 4 runs/day × 7 days. Adjust with the window.
+
+This job auto-disables when expires_after passes OR max_runs is exhausted —
+whichever comes first. No manual cleanup needed.
+-->
+
+REPO=TODO:owner/repo
+OUTPUT_FILE=~/.clauck/release-monitor-feed.md
+
+You are monitoring **REPO** during its release window. This job fires every 6 hours and auto-disables when the window closes.
+
+**Each run:**
+
+1. Run `gh issue list --repo REPO --state open --json number,title,labels,createdAt` and filter for issues created in the last 6 hours. If `gh` is unavailable, note it and skip.
+
+2. Categorize:
+   - **Bugs/blockers**: issues labeled `bug`, `critical`, `regression`, or containing "broken", "crash", "fails", "error" in title
+   - **Feedback**: labeled `enhancement`, `question`, or "feature request" in title
+   - **Other**: everything else
+
+3. Append to OUTPUT_FILE:
+
+```
+## YYYY-MM-DD HH:MM UTC — release-monitor (REPO)
+Bugs/blockers (N): #123 short title, #456 short title
+Feedback (N): #789 short title
+Other (N): #012 short title
+Nothing new since last check.
+```
+
+If no new issues: write a single `## YYYY-MM-DD HH:MM UTC — nothing new` line and exit.
+
+One issue per line max. Titles truncated to 60 chars. This is a log, not a report.

--- a/marketplace/standup-gather.md
+++ b/marketplace/standup-gather.md
@@ -1,0 +1,45 @@
+---
+name: standup-gather
+description: Pipeline stage — collects git commits from the last 24h across repos. Output consumed by the standup job.
+cron: ""
+max_turns: 4
+max_budget_usd: 0.05
+cwd: ~
+effort: low
+model: haiku
+setting_sources: ""
+strict_mcp_config: true
+tags:
+  - developer
+  - pipeline
+  - standup
+  - pipeline-stage
+---
+
+<!--
+CUSTOMIZE BEFORE INSTALLING:
+1. Set REPOS_ROOT to your repos parent directory.
+2. Install standup.md alongside this job — it uses standup-gather as a producer.
+-->
+
+REPOS_ROOT=~/code
+
+Scan REPOS_ROOT for git activity from the last 24 hours. For each direct subdirectory:
+- Check if it is a git repo: `git -C <dir> rev-parse --git-dir 2>/dev/null`
+- If yes: run `git -C <dir> log --since="24 hours ago" --oneline --all`
+- Collect: repo name, commit count, up to 3 one-line summaries
+
+Output ONLY this JSON block (no preamble, no explanation):
+
+```json
+{
+  "repos": [
+    {"name": "repo-name", "commits": 3, "summaries": ["fix auth bug", "add tests", "bump version"]}
+  ],
+  "total_commits": 3,
+  "repos_root": "REPOS_ROOT"
+}
+```
+
+If no repos have activity, output `{"repos": [], "total_commits": 0, "repos_root": "REPOS_ROOT"}`.
+If REPOS_ROOT does not exist or is not a directory, output `{"repos": [], "total_commits": 0, "repos_root": "REPOS_ROOT", "error": "REPOS_ROOT not found"}`.

--- a/marketplace/standup.md
+++ b/marketplace/standup.md
@@ -1,0 +1,57 @@
+---
+name: standup
+description: Weekday standup generator — pulls git activity via standup-gather pipeline, writes a formatted standup note.
+cron: "0 13 * * 1-5"
+max_turns: 6
+max_budget_usd: 0.08
+cwd: ~
+effort: low
+model: haiku
+setting_sources: ""
+strict_mcp_config: true
+producers:
+  - {name: standup-gather, timeout_seconds: 120}
+tags:
+  - productivity
+  - developer
+  - pipeline
+  - standup
+semantic_hooks:
+  - Write my daily standup from git commits
+  - Generate a standup report from recent code activity
+  - Create a standup note from yesterday's work
+---
+
+<!--
+CUSTOMIZE BEFORE INSTALLING:
+1. Set OUTPUT_FILE to where you want standups written.
+   Default writes to ~/standup.md — change to match your workflow.
+2. Adjust cron time to your standup time (default: 13:00 UTC = 8am ET).
+3. Install standup-gather.md alongside this job.
+
+This job uses standup-gather as a producer (pipeline pattern):
+  standup-gather runs first → collects git data → output injected here
+  standup formats the data → appends to OUTPUT_FILE
+-->
+
+OUTPUT_FILE=~/standup.md
+
+Read the `## Producer outputs` section in your runtime context — it contains JSON output from standup-gather with today's git activity.
+
+Parse the JSON and format a concise standup. Append to OUTPUT_FILE (never overwrite):
+
+```
+## YYYY-MM-DD standup
+Yesterday:
+- [repo-name]: brief summary of work from commit messages (N commits)
+- [repo-name]: ...
+Today: continuing [inferred area from commit patterns] / (leave blank if unclear)
+Blockers: none
+```
+
+Rules:
+- One bullet per repo. Summarize from commit messages — don't just list them.
+- "Today" line: infer from patterns if obvious, otherwise omit it.
+- "Blockers": always include — say "none" if no evidence of blockers in commits.
+- If total_commits is 0: append `## YYYY-MM-DD — no commits to report`.
+- If producer output is missing or malformed: append `## YYYY-MM-DD — standup-gather produced no output`.

--- a/marketplace/work-journal.md
+++ b/marketplace/work-journal.md
@@ -1,0 +1,52 @@
+---
+name: work-journal
+description: Session-persistent daily work journal — accumulates context across runs to surface patterns and track momentum over time.
+cron: "0 22 * * 1-5"
+max_turns: 8
+max_budget_usd: 0.08
+cwd: ~
+effort: low
+model: haiku
+session_persist: true
+setting_sources: ""
+strict_mcp_config: true
+tags:
+  - productivity
+  - journal
+  - developer
+  - session-persist
+semantic_hooks:
+  - Write a daily summary of work completed today
+  - Build a running work journal from git activity
+  - Log what I worked on today
+---
+
+<!--
+CUSTOMIZE BEFORE INSTALLING:
+1. Set REPOS_ROOT to the parent directory containing your git repos.
+   Example: REPOS_ROOT=~/Projects  or  REPOS_ROOT=~/code
+2. Set OUTPUT_FILE to where you want the journal written.
+3. Adjust cron time to your end-of-workday (default: 22:00 UTC / 5pm ET).
+-->
+
+REPOS_ROOT=~/code
+OUTPUT_FILE=~/.clauck/work-journal.md
+
+You are maintaining a running work journal across multiple sessions. Because session_persist is enabled, you have full context from every prior run of this job. Use that history to notice patterns.
+
+**Step 1 — Gather today's git activity.**
+For each direct subdirectory of REPOS_ROOT: check if it's a git repo (`git -C <dir> rev-parse --git-dir 2>/dev/null`). If yes, run `git -C <dir> log --since="24 hours ago" --oneline --all`. Collect: repo name, commit count, up to 3 commit summaries. Skip repos with no activity.
+
+**Step 2 — Write today's entry.**
+Append to OUTPUT_FILE (never overwrite):
+
+```
+## YYYY-MM-DD
+- [repo-name] N commits — summary of work (e.g., "fixed auth bug, added tests")
+- [repo-name] ...
+↑ [optional 1-line pattern note if you see something recurring across sessions]
+```
+
+If no git activity anywhere: append `## YYYY-MM-DD — no commits`.
+
+Terse. One bullet per repo. The optional pattern note fires only when you notice something meaningful spanning multiple days — skip it if nothing stands out.


### PR DESCRIPTION
## Closes #9

## Motivation

The clauck marketplace has 7 jobs, all using v0.1.0-era features. Users browsing the marketplace see only simple cron jobs — no installable example of session persistence, temporal scheduling, or producer/consumer pipelines. These are among clauck's most powerful differentiators but remain invisible until someone has already internalized the docs.

This PR adds 4 marketplace jobs that make each post-v0.1.0 capability installable and observable.

## Before / After

| | Before | After |
|---|---|---|
| `session_persist` | Documented in SKILL.md + schema | Installable `work-journal` job demonstrating it end-to-end |
| `valid_after` / `expires_after` / `max_runs` | Documented in SKILL.md | Installable `release-monitor` job demonstrating bounded temporal scheduling |
| `producers` / `consumers` | Documented in SKILL.md with abstract examples | Installable 2-job `standup-gather + standup` pipeline |
| Marketplace job count | 7 | 11 |

## New jobs

### `work-journal.md` — session_persist demo
Weekday end-of-day: scans git repos for today's commits, appends a structured entry to `~/.clauck/work-journal.md`. `session_persist: true` means each run has full context from prior runs — the job can notice recurring patterns across days. `strict_mcp_config + setting_sources: ""` → ~$0.04/run on Haiku. No MCPs required.

### `release-monitor.md` — temporal window demo
Monitors a GitHub repo for new issues every 6 hours during a configurable release window. `valid_after` + `expires_after` + `max_runs`: the job auto-disables when the window closes. The CUSTOMIZE block guides users to set both dates, making the temporal pattern explicit. Uses `gh` CLI.

### `standup-gather.md` + `standup.md` — pipeline demo
Two-job pipeline: `standup-gather` (ad-hoc, no cron) collects git commits and outputs structured JSON; `standup` (weekday cron, `producers: [{name: standup-gather}]`) reads `## Producer outputs` and formats a standup note. The pair demonstrates the full producers/consumers contract end-to-end.

## Cost:value

- **Change size:** 4 new `.md` files + 80-line `index.json` update. No code changes.
- **Risk:** Zero — purely additive content. All existing jobs unchanged.
- **Value:** Each installed job produces observable output on first run. Concrete behavior beats documentation.

## Confidence:impact

- **Confidence:** High. All jobs use only documented frontmatter fields. `json.load(open('marketplace/index.json'))` passes. All CLAUDE.md checks pass.
- **Impact:** Medium. Makes advanced features browsable and installable. Directly closes #9.

## Validation steps

```bash
# 1. Validate index.json
/usr/bin/python3 -c "import json; d = json.load(open('marketplace/index.json')); print(len(d['jobs']), 'jobs')"
# → 11 jobs

# 2. Install and fire work-journal
cp marketplace/work-journal.md ~/.clauck/
clauck fire work-journal
# → should append entry to ~/.clauck/work-journal.md

# 3. Install pipeline pair
cp marketplace/standup-gather.md marketplace/standup.md ~/.clauck/
# Edit REPOS_ROOT in standup-gather.md
clauck fire standup
# → triggers standup-gather as producer, then writes ~/standup.md

# 4. Verify release-monitor valid_after suppression
# Set valid_after to tomorrow, install, fire ad-hoc → noop (valid_after in future)
```

## Supporting artifacts

- Closes [#9](https://github.com/CoreyRDean/clauck/issues/9)
- `feature_demo` field added to new index entries so agents/users can filter by demonstrated capability