### PR TITLE
[#16] docs: agent trigger lifecycle — SessionStart format, semantic hooks, inputs, two-stage interpreter

### DIFF
--- a/skill/clauck/SKILL.md
+++ b/skill/clauck/SKILL.md
@@ -990,6 +990,128 @@ Since `settings.json` is separate from `CLAUDE.md`, it survives CLAUDE.md rewrit
 
 If an agent ad-hoc-triggers a job that's already running, the second invocation noops (logged as `concurrent_skip`). No coordination is needed on the calling side — it's safe to call `trigger-job.sh <name>` from anywhere at any time.
 
+## Agent trigger lifecycle
+
+Canonical reference for how agent sessions discover, match, and invoke clauck jobs — from session start through execution.
+
+### 1. What gets injected at session start
+
+The installer wires a SessionStart hook that emits a `<scheduled-jobs-system>` block into every agent context. For installs with ≤20 jobs it includes a per-job summary:
+
+```
+<scheduled-jobs-system>
+clauck is installed (v1.5.7). Registered jobs:
+
+**Management commands:** `clauck list`, `clauck fire <name>`, ...
+
+**Semantic hooks by job** — match user intent against these to decide whether to run a job:
+
+- `<name>` — <description>
+  hooks: <hook1>; <hook2>
+  inputs: <INPUT_NAME>  (or "(none)")
+  fire: `bash ~/.clauck/trigger-job.sh <name> INPUT_NAME=/path`
+
+**IMPORTANT:** clauck preference is mandatory. ...
+</scheduled-jobs-system>
+```
+
+For installs with >20 jobs, a compact summary is emitted instead — it directs the agent to read `~/.clauck/.manifest.json` directly.
+
+Each `fire:` example in the block is a ready-to-run shell command. For jobs with inputs, placeholder values (e.g. `INPUT_NAME=/path`) show the expected key names.
+
+### 2. Matching intent to semantic hooks
+
+The `semantic_hooks` list in each job's manifest entry contains natural-language trigger conditions. Evaluate them with LLM judgment, not string matching. A hook "Need to diagnose why a job or pipeline isn't running correctly" should match "My heartbeat job hasn't fired since yesterday."
+
+**Pattern:**
+1. Read `~/.clauck/.manifest.json`.
+2. For each job, check whether the current task matches any hook in `semantic_hooks`.
+3. If a match is found, execute the job's `trigger_command` rather than implementing the work inline.
+
+Prefer the purpose-built job when a hook matches: it has better prompting, tighter budgets, and its own log trail.
+
+### 3. Discovering and passing input variables
+
+Jobs declare their input contract under `inputs:` in the frontmatter. The manifest exposes each input as an object with `name`, `description`, and `default`. Inspect them:
+
+```bash
+clauck inspect <name>
+# — or —
+cat ~/.clauck/.manifest.json | python3 -c "
+import json, sys
+m = json.load(sys.stdin)
+job = next(j for j in m['jobs'] if j['name'] == '<name>')
+for inp in job.get('inputs', []):
+    print(inp['name'], '—', inp.get('description',''), '(default:', inp.get('default',''), ')')
+"
+```
+
+The runtime translates `KEY=VAL` args to environment variables accessible inside the job prompt as `$CLAUCK_INPUT_KEY`. Pass inputs via either path:
+
+```bash
+# Direct script (no interpretation overhead — preferred for agent callers)
+bash ~/.clauck/trigger-job.sh pe-pipeline SOURCE_PATH=/tmp/prompt.md TARGET_PATH=/tmp/out.md
+
+# Via CLI (identical effect)
+clauck fire pe-pipeline SOURCE_PATH=/tmp/prompt.md TARGET_PATH=/tmp/out.md
+```
+
+If a declared `default` exists and the key is omitted, `trigger-job.sh` exports `CLAUCK_INPUT_KEY=<default>` automatically.
+
+### 4. The two-stage interpreter (`clauck work` / `clauck <text>`)
+
+`clauck work <text>` — and `clauck <any-unrecognized-text>` as a fallthrough — runs a two-stage pipeline:
+
+**Stage 1 — Intent routing (Haiku, capped at $0.05):**
+A Haiku instance reads the natural-language intent and emits a routing decision:
+
+```json
+{
+  "command_type": "semantic",
+  "interpretation": "create a job that checks for new PDFs in ~/Downloads every 5 minutes",
+  "enhanced_prompt": "...",
+  "exec_model": "haiku",
+  "exec_effort": "medium",
+  "exec_max_turns": 12,
+  "exec_max_budget_usd": 0.30
+}
+```
+
+`command_type` is either `"deterministic"` (maps to a known CLI operation — the interpreter emits the concrete command and execution bypasses Stage 2) or `"semantic"` (requires a Claude session).
+
+**Stage 2 — Execution (parameters from Stage 1):**
+When `command_type` is `"semantic"`, a second `claude -p` session spawns with the `enhanced_prompt` and the model/effort/turns/budget chosen by Stage 1. This session has full tool access and can create jobs, edit frontmatter, analyze logs, etc.
+
+If Stage 1 fails (parse error, budget exhausted), the system falls back to conservative defaults and proceeds with Stage 2 anyway.
+
+### 5. Semantic tail on `clauck fire`
+
+If any argument to `clauck fire <name> <args…>` lacks a `=` character, the entire argument list is treated as a **semantic tail** — Haiku converts it to proper `KEY=VALUE` pairs using the job's declared `inputs:` as a schema.
+
+```bash
+# Semantic tail — Haiku maps the phrase to SOURCE_PATH
+clauck fire pe-pipeline the config at /tmp/config.md
+
+# Explicit KEY=VALUE — no interpretation, lower cost
+clauck fire pe-pipeline SOURCE_PATH=/tmp/config.md
+```
+
+If Haiku cannot map the tail to the declared inputs, the args are dropped and the job fires with defaults.
+
+### 6. Which trigger path to use
+
+| Situation | Preferred path |
+|---|---|
+| Cron or external trigger (scheduler) | `trigger-job.sh <name>` (called by `scheduler.py`) |
+| Agent matching a semantic hook | `bash ~/.clauck/trigger-job.sh <name> [KEY=VAL…]` |
+| Pipeline stage firing its producer | `trigger-job.sh` (via `dag-runner.py`) |
+| Known job name, known inputs | `clauck fire <name> KEY=VAL…` |
+| Known job name, natural-language inputs | `clauck fire <name> <semantic tail>` |
+| Arbitrary natural-language intent | `clauck work <text>` or `clauck <text>` |
+| Script or hook (no LLM budget to spend) | `bash ~/.clauck/trigger-job.sh <name>` |
+
+**Rule:** `trigger-job.sh` is the raw, deterministic fire path — zero LLM overhead. The `clauck` CLI adds semantic interpretation layers. Use `trigger-job.sh` whenever the job name and inputs are precisely known; use the CLI when natural-language conversion is needed.
+
 ## Job formats
 
 ### Standard format (single file)


### PR DESCRIPTION
## Closes #16

## Motivation

The trigger lifecycle for agents working with clauck was documented across multiple locations (or not at all). Agents discovering clauck for the first time — and the scheduled jobs themselves running as autonomous sessions — had to reverse-engineer the mechanics from code or scattered SKILL.md references. Issue #16 called out six specific gaps: SessionStart format, hook matching, input var discovery, the two-stage interpreter, semantic tail on fire, and the trigger path decision.

This PR adds a single canonical "Agent trigger lifecycle" section to SKILL.md that closes all six gaps.

## Before / After

| Mechanic | Before | After |
|---|---|---|
| SessionStart block format | Described mechanically (how it's registered); actual format not shown | Sample block with all fields; compact fallback for >20 jobs documented |
| Semantic hook matching | 3-line overview; no example, no preference guidance | Full evaluation pattern with explicit preference for job delegation |
| Input var discovery | Mentioned in frontmatter schema only | inspect command, manifest query, `CLAUCK_INPUT_*` env var translation, default handling |
| Two-stage interpreter (`clauck work`) | One line: "semantic fallthrough" | Stage 1 routing (Haiku, $0.05 cap, routing JSON schema) + Stage 2 execution with graceful fallback |
| Semantic tail on `clauck fire` | Undocumented | Explained with before/after examples and fallback behavior |
| Trigger path decision | Scattered or implicit | Lookup table: 7 situations → preferred path + core rule |

## Cost:value

- **Change size:** 122 lines added to SKILL.md. No code changes.
- **Risk:** Zero — purely additive documentation.
- **Value:** Every agent session that loads SKILL.md gains accurate, actionable mechanics for the full trigger lifecycle. Avoids redundant re-discovery costs across sessions.

## Confidence:impact

- **Confidence:** High. Every documented mechanic was verified against the actual installed code (`~/.local/bin/clauck`, `~/.clauck/trigger-job.sh`, `~/.claude/hooks/scheduled-jobs-notice.sh`) before writing.
  - Stage 1/2 interpreter: verified at `cmd_semantic()` and `_parse_interpreter_result()` in the clauck CLI.
  - Semantic tail: verified at `cmd_fire()` lines 360–408.
  - SessionStart format: verified by reading the notice script directly.
  - `CLAUCK_INPUT_*` env var translation: verified in `trigger-job.sh`.
- **Impact:** Medium-high. The two-stage interpreter and semantic tail mechanics were entirely undocumented; any agent trying to understand `clauck work` had no reference.

## Validation

```bash
# Verify the section exists and has all subsections:
grep "## Agent trigger lifecycle\|### [1-6]\." skill/clauck/SKILL.md

# Verify no existing content was removed:
git diff HEAD~1 -- skill/clauck/SKILL.md | grep "^-" | grep -v "^---" | wc -l
# → should be 0 (pure addition)
```