### PR TITLE
feat: CLAUCK_OUTPUT_DIR — standard output location for job deliverables

### DIFF
--- a/lib/run-job.sh
+++ b/lib/run-job.sh
@@ -157,6 +157,25 @@ echo "stage=resolved claude=$CLAUDE_BIN" >> "$LOG_FILE"
 cd "$JOB_CWD" || die "cwd unreachable: $JOB_CWD" 5
 echo "stage=cwd cwd=$(pwd)" >> "$LOG_FILE"
 
+# --- Resolve CLAUCK_OUTPUT_DIR from config (fallback: ~/Documents/clauck) ---
+# Allow the caller to override by pre-setting CLAUCK_OUTPUT_DIR in the env.
+if [ -z "${CLAUCK_OUTPUT_DIR:-}" ]; then
+  CONFIG_FILE="$JOBS_DIR/.clauck.config.json"
+  CLAUCK_OUTPUT_DIR="$(/usr/bin/python3 -c "
+import json, os
+try:
+    data = json.loads(open('$CONFIG_FILE').read())
+    print(data.get('output_dir', '~/Documents/clauck'))
+except Exception:
+    print('~/Documents/clauck')
+" 2>/dev/null || echo "$HOME/Documents/clauck")"
+  # Expand leading ~ to $HOME (Read tool and other tools do not expand tilde)
+  CLAUCK_OUTPUT_DIR="${CLAUCK_OUTPUT_DIR/#\~/$HOME}"
+fi
+export CLAUCK_OUTPUT_DIR
+mkdir -p "$CLAUCK_OUTPUT_DIR" 2>/dev/null || true
+echo "stage=output_dir output_dir=$CLAUCK_OUTPUT_DIR" >> "$LOG_FILE"
+
 # --- Strip YAML frontmatter before passing prompt to claude ---
 # State machine: init → (inside between --- markers) → body.
 PROMPT_BODY="$(awk '
@@ -192,6 +211,7 @@ RUNTIME_CONTEXT="# Runtime Context (this invocation)
 - **Jobs directory:** ${JOBS_DIR}
 - **Manifest (all jobs, with semantic_hooks and trigger_commands):** ${JOBS_DIR}/.manifest.json
 - **Per-job state directory:** ${JOBS_DIR}/.state/
+- **Output directory:** ${CLAUCK_OUTPUT_DIR}
 
 Spend proportional to value. Budget is a cap, not a target. If there is nothing meaningful to do, exit cleanly with a brief note — a no-op is a legitimate outcome for a scheduled invocation.
 These limits are enforced — exceeding max_budget_usd or max_turns terminates the session immediately.

--- a/lib/scheduler.py
+++ b/lib/scheduler.py
@@ -843,7 +843,8 @@ def load_config() -> dict:
             "enabled": True,
             "check_interval_seconds": 3600,
             "auto_apply": False,
-        }
+        },
+        "output_dir": "~/Documents/clauck",
     }
     if not CONFIG_PATH.exists():
         return defaults

--- a/marketplace/git-commit-nudge.md
+++ b/marketplace/git-commit-nudge.md
@@ -34,7 +34,7 @@ For each repo, run:
 1. `git -C <repo> status --porcelain` — any output means uncommitted changes.
 2. `git -C <repo> log @{u}.. --oneline 2>/dev/null` — any output means unpushed commits. If no upstream is set, skip this check.
 
-Collect results. If ANY repo has uncommitted or unpushed work, append to `~/.clauck/git-nudge-feed.md`:
+Collect results. If ANY repo has uncommitted or unpushed work, append to `$CLAUCK_OUTPUT_DIR/git-nudge-feed.md` (this path is in your Runtime Context under **Output directory**):
 
 ```
 ## <ISO8601 UTC>
@@ -48,6 +48,6 @@ Collect results. If ANY repo has uncommitted or unpushed work, append to `~/.cla
 - ...
 ```
 
-If all repos are clean: write `## <UTC>: all repos clean` and exit.
+If all repos are clean: write `## <UTC>: all repos clean` to the same feed file and exit.
 
 **Do not commit, push, stash, or modify any repo.** Report only.

--- a/marketplace/inbox-zero-assist.md
+++ b/marketplace/inbox-zero-assist.md
@@ -34,7 +34,7 @@ Search Gmail for unread threads older than 48 hours. For each (cap at 15):
 1. Note: sender, subject, age, snippet.
 2. Suggest ONE action: `reply` (draft a one-liner), `archive` (not actionable), `delegate` (forward to someone), `schedule` (needs attention but not now).
 
-Append to `~/.clauck/inbox-assist-feed.md`:
+Append to `$CLAUCK_OUTPUT_DIR/inbox-assist-feed.md` (this path is in your Runtime Context under **Output directory**):
 
 ```
 ## <ISO8601 UTC>
@@ -50,4 +50,4 @@ Unread threads older than 48h: N total, N shown above.
 
 **Do not send, archive, label, or modify any email.** Read-only + local suggestions.
 
-If no unread threads older than 48h: write `## <UTC>: inbox zero ✓` and exit.
+If no unread threads older than 48h: write `## <UTC>: inbox zero ✓` to the same feed file and exit.

--- a/skill/clauck/SKILL.md
+++ b/skill/clauck/SKILL.md
@@ -135,6 +135,48 @@ When the user wants a new job that isn't in the marketplace, elicit these in ord
 
 Once collected, write `~/.clauck/<name>.md`, ad-hoc fire to verify, and report.
 
+## Output directory convention
+
+Jobs that produce user-facing deliverables (reports, summaries, feed files, journal entries) should write to `$CLAUCK_OUTPUT_DIR` rather than to `~/.clauck/` or `~/`.
+
+`~/.clauck/` and `~/.clauck/.state/` are internal directories — logs, manifests, locks, and runtime state. User-facing output buried there is hard to find. `~/` is noisy. `$CLAUCK_OUTPUT_DIR` groups deliverables in one identifiable place.
+
+### What the runtime provides
+
+Every job receives `CLAUCK_OUTPUT_DIR` as an environment variable and as a line in the Runtime Context:
+
+```
+- **Output directory:** /Users/you/Documents/clauck
+```
+
+The directory is created automatically before the job runs. Job prompts can reference it as `$CLAUCK_OUTPUT_DIR` without expansion concerns.
+
+### Default location
+
+`~/Documents/clauck` — uses the standard macOS Documents folder, grouped under a `clauck/` subfolder so deliverables are identifiable without polluting the parent.
+
+### Configure the output directory
+
+Add `output_dir` to `~/.clauck/.clauck.config.json`:
+
+```json
+{
+  "output_dir": "~/Documents/clauck"
+}
+```
+
+Set any path you prefer. Tilde is expanded automatically.
+
+### Writing new marketplace jobs
+
+Use `$CLAUCK_OUTPUT_DIR` as the output location. Reference the Runtime Context line if you want the resolved path in the prompt:
+
+```
+Append to `$CLAUCK_OUTPUT_DIR/my-feed.md` (the **Output directory** in your Runtime Context).
+```
+
+`.state/` is still appropriate for internal artifacts the user doesn't need to read directly (lock files, producer outputs, trigger state).
+
 ## Auto-update configuration
 
 Config file: `~/.clauck/.clauck.config.json`


### PR DESCRIPTION
Closes #42

## Motivation

Jobs that produce user-facing files have no agreed-upon home. `git-commit-nudge` and `inbox-zero-assist` both wrote to `~/.clauck/` — an internal directory holding logs, locks, and runtime state. Users had to know to look there. Other jobs wrote to `~/` directly, cluttering the home root. Neither is discoverable.

## Before / After

**Before:** Each job hard-codes a path or omits one entirely. Output goes to `~/.clauck/git-nudge-feed.md`, `~/.clauck/inbox-assist-feed.md`, or nowhere predictable.

**After:** Every job receives `CLAUCK_OUTPUT_DIR` (an env var and a Runtime Context line) pointing to a resolved, auto-created directory. Default is `~/Documents/clauck`. Jobs reference `$CLAUCK_OUTPUT_DIR/feed-name.md` and the user always knows where to look.

## What changed

| File | Change |
|---|---|
| `lib/run-job.sh` | Read `output_dir` from `.clauck.config.json` (default `~/Documents/clauck`), expand tilde, create dir, export `CLAUCK_OUTPUT_DIR`, inject into Runtime Context |
| `lib/scheduler.py` | Add `output_dir` to `load_config()` defaults so the key is always present in merged config |
| `marketplace/git-commit-nudge.md` | Use `$CLAUCK_OUTPUT_DIR/git-nudge-feed.md` instead of `~/.clauck/git-nudge-feed.md` |
| `marketplace/inbox-zero-assist.md` | Use `$CLAUCK_OUTPUT_DIR/inbox-assist-feed.md` instead of `~/.clauck/inbox-assist-feed.md` |
| `skill/clauck/SKILL.md` | New **Output directory convention** section documenting the feature |

## Cost-to-value

~68 lines across 5 files. No new dependencies, no new frontmatter fields, backward-compatible (env var is silently available to all jobs). Existing jobs that don't reference `$CLAUCK_OUTPUT_DIR` are unaffected.

## Confidence-to-impact

- `run-job.sh` syntax verified with `bash -n`
- `scheduler.py` AST-parsed with `ast.parse()`
- The Python one-liner in `run-job.sh` has an explicit fallback (`echo "$HOME/Documents/clauck"`) if Python is unavailable or the config is missing
- `mkdir -p ... || true` ensures failure to create the directory doesn't abort the job
- Tilde expansion uses `${VAR/#\~/$HOME}` (bash 3.2 compatible per project rules)

## Validation steps

1. Install from this branch: `bash install.sh --yes` (or apply the 5 changed files manually to `~/.clauck/`)
2. Fire a job: `~/.clauck/trigger-job.sh heartbeat`
3. Check the log: `grep output_dir ~/.clauck/heartbeat-*.log | tail -1` — should show `output_dir=/Users/<you>/Documents/clauck`
4. Confirm the directory was created: `ls ~/Documents/clauck/`
5. Optionally set a custom path: add `"output_dir": "~/Desktop/clauck"` to `~/.clauck/.clauck.config.json`, re-fire, verify the new path appears in the log

## Falsifiability

If `~/Documents/clauck` is created on every job run even when users haven't opted into deliverable output, that's noise and the default should be deferred (create on first write, not on every run). The `mkdir -p` call would need to move into job prompts that actually write deliverables.