### PR TITLE
[#5] feat: trace_tool_calls — stream-json mode for per-job tool-call visibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ valid_after: "<ISO date>"            # don't fire until this date
 expires_after: "<ISO date>"          # auto-disable after this date
 session_persist: <bool>              # reuse session across runs (--resume)
 interactive: <bool>                  # open Terminal after run for follow-up
+trace_tool_calls: <bool>             # log every tool call (stream-json mode; grep "tool_use")
 tags:                                # freeform categorization
   - <tag1>
   - <tag2>

--- a/lib/dag-runner.py
+++ b/lib/dag-runner.py
@@ -379,6 +379,8 @@ def execute_job(
         env["CLAUDE_JOB_DEBOUNCE_SECONDS"] = str(job_config["debounce_seconds"])
     if job_config.get("session_persist"):
         env["CLAUDE_JOB_SESSION_PERSIST"] = "1"
+    if job_config.get("trace_tool_calls"):
+        env["CLAUDE_JOB_TRACE_TOOL_CALLS"] = "1"
 
     # DAG-specific env vars so run-job.sh can find the producer outputs.
     env["CLAUDE_DAG_INVOCATION_ID"] = invocation_id

--- a/lib/run-job.sh
+++ b/lib/run-job.sh
@@ -15,6 +15,8 @@
 #                                     dropping the user's full MCP surface from the prompt)
 #   CLAUDE_JOB_DEBOUNCE_SECONDS      (optional; skip this invocation if the job was last started
 #                                     within the window. 0 or unset = no debounce)
+#   CLAUDE_JOB_TRACE_TOOL_CALLS      (sentinel: "1" → use stream-json output so every tool
+#                                     call appears in the log. Grep for "tool_use" to inspect.)
 #   CLAUDE_JOB_CRON           (cron expression; informational)
 #   CLAUDE_JOB_TRIGGER        ("scheduled" or "adhoc"; default "scheduled")
 #   CLAUDE_JOB_FIRED_AT       (ISO8601 UTC timestamp from scheduler; informational)
@@ -46,6 +48,9 @@ MAX_TURNS="${CLAUDE_JOB_MAX_TURNS:-50}"
 MAX_BUDGET_USD="${CLAUDE_JOB_MAX_BUDGET_USD:-2.00}"
 EFFORT="${CLAUDE_JOB_EFFORT:-high}"
 MODEL="${CLAUDE_JOB_MODEL:-}"
+# stream-json when trace_tool_calls is set; tool events appear inline in the log.
+OUTPUT_FORMAT="json"
+[ "${CLAUDE_JOB_TRACE_TOOL_CALLS:-}" = "1" ] && OUTPUT_FORMAT="stream-json"
 DEBOUNCE_SECONDS="${CLAUDE_JOB_DEBOUNCE_SECONDS:-0}"
 CRON_EXPR="${CLAUDE_JOB_CRON:-}"
 TRIGGER="${CLAUDE_JOB_TRIGGER:-manual}"
@@ -371,7 +376,7 @@ CLAUDE_ARGS=(
   --effort "$EFFORT"
   --max-turns "$MAX_TURNS"
   --max-budget-usd "$MAX_BUDGET_USD"
-  --output-format json
+  --output-format "$OUTPUT_FORMAT"
 )
 [ -n "$MODEL" ] && CLAUDE_ARGS+=(--model "$MODEL")
 # Only add --setting-sources if the job explicitly opted in (including setting it
@@ -421,7 +426,7 @@ if [ "$EXIT_CODE" -ne 0 ] && [ "${CLAUDE_JOB_SESSION_PERSIST:-}" = "1" ] && [ -f
       --effort "$EFFORT"
       --max-turns "$MAX_TURNS"
       --max-budget-usd "$MAX_BUDGET_USD"
-      --output-format json
+      --output-format "$OUTPUT_FORMAT"
     )
     [ -n "$MODEL" ] && CLAUDE_ARGS+=(--model "$MODEL")
     [ -n "${CLAUDE_JOB_SETTING_SOURCES_SET:-}" ] && CLAUDE_ARGS+=(--setting-sources "${CLAUDE_JOB_SETTING_SOURCES:-}")

--- a/lib/scheduler.py
+++ b/lib/scheduler.py
@@ -284,6 +284,10 @@ def discover_jobs() -> list[dict]:
                 # running session visible, and leaves it open for user
                 # follow-up after completion.
                 "interactive": bool(fm.get("interactive", False)),
+                # trace_tool_calls: if true, switches output format to
+                # stream-json so every tool call appears in the log.
+                # Useful for pipeline debugging.
+                "trace_tool_calls": bool(fm.get("trace_tool_calls", False)),
                 # --- triggers ---
                 # external_triggers: list of flow-style-object conditions that,
                 # if met, cause the job to fire between cron slots. Evaluated
@@ -347,6 +351,7 @@ def discover_jobs() -> list[dict]:
                 "expires_after": str(fm.get("expires_after", "")).strip(),
                 "session_persist": bool(fm.get("session_persist", False)),
                 "interactive": bool(fm.get("interactive", False)),
+                "trace_tool_calls": bool(fm.get("trace_tool_calls", False)),
                 "external_triggers": list(fm.get("external_triggers", []) or []),
                 "semantic_hooks": list(fm.get("semantic_hooks", []) or []),
                 "tags": list(fm.get("tags", []) or []),
@@ -398,6 +403,7 @@ def discover_jobs() -> list[dict]:
                     "expires_after": str(stage_fm.get("expires_after", "")).strip(),
                     "session_persist": bool(stage_fm.get("session_persist", False)),
                     "interactive": bool(stage_fm.get("interactive", False)),
+                    "trace_tool_calls": bool(stage_fm.get("trace_tool_calls", False)),
                     "external_triggers": list(stage_fm.get("external_triggers", []) or []),
                     "semantic_hooks": list(stage_fm.get("semantic_hooks", []) or []),
                     "tags": list(stage_fm.get("tags", []) or []),
@@ -777,6 +783,8 @@ def fire(job: dict, trigger: str = "scheduled") -> None:
         env["CLAUDE_JOB_SESSION_PERSIST"] = "1"
     if job.get("interactive"):
         env["CLAUDE_JOB_INTERACTIVE"] = "1"
+    if job.get("trace_tool_calls"):
+        env["CLAUDE_JOB_TRACE_TOOL_CALLS"] = "1"
     env["CLAUDE_JOB_TRIGGER"] = trigger
     env["CLAUDE_JOB_FIRED_AT"] = datetime.now(timezone.utc).isoformat()
 


### PR DESCRIPTION
## Motivation

When a pipeline stage or scheduled job fails silently, the `--output-format json` mode gives you the final result but hides everything that happened in between. You cannot tell whether the agent called `Read` and got an error, never called it at all, or called it on the wrong path. This makes pipeline debugging a guess.

## Before / After

**Before:** Job logs contain one JSON blob at the end. Tool calls are invisible.

```
{"type":"result","subtype":"success","result":"...", ...}
```

**After:** With `trace_tool_calls: true`, every tool event streams inline into the log:

```
{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_...","name":"Read","input":{"file_path":"/Users/..."}}],...}}
{"type":"tool_result","tool_use_id":"toolu_...","content":[...]}
{"type":"result","subtype":"success",...}
```

Grep the log: `grep '"name":"' intent-miner-*.log` shows every tool called and its inputs.

## Cost-to-Value

- 18 lines added, 2 changed across 4 files
- No new dependencies
- Zero change to default behavior (opt-in via frontmatter)
- `OUTPUT_FORMAT` variable is set once and reused in both the primary invocation and the stale-session retry path, so no drift between the two code paths

## Confidence-to-Impact

- Backwards compatible: `trace_tool_calls` defaults to `false`; existing jobs are unaffected
- All three job discovery paths updated (flat jobs, module anchors, module stages)
- `dag-runner.py` forwards the flag to pipeline stages
- `bash -n` and `ast.parse` pass on all modified files
- Session-id extraction regex (`grep '"session_id":"'`) works on both `json` and `stream-json` output since the final `result` event contains the same field

## Validation Steps

1. Add `trace_tool_calls: true` to any job's frontmatter
2. Fire it: `clauck fire <job-name>`
3. Open the log: `cat ~/.clauck/<job-name>-<ts>-<pid>.log`
4. Confirm tool_use events appear inline before the final result line
5. Grep: `grep '"type":"tool_use"' ~/.clauck/<job-name>-*.log` returns results

To verify no regression on default jobs: fire any existing job without the flag and confirm output is unchanged.

## Related

Closes #5