### PR TITLE
[#11] feat: clauck marketplace info and search commands

### DIFF
--- a/lib/clauck
+++ b/lib/clauck
@@ -13,6 +13,8 @@ Usage:
     clauck remove <name>                 Delete a job + its state (also: delete, rm)
     clauck logs <name> [--last N]        Show recent logs
     clauck marketplace                    Browse pre-made jobs
+    clauck marketplace info <name>        Show full details for a marketplace job
+    clauck marketplace search <query>     Search marketplace by keyword
     clauck marketplace updates            Show installed jobs with newer versions available
     clauck install <marketplace-job>     Install from marketplace
     clauck install <name> --update       Overwrite installed job with latest marketplace version
@@ -654,6 +656,87 @@ def cmd_marketplace(filter_tag: str = "") -> None:
         all_tags.update(j.get("tags", []))
     print(f"\n  filter by tag: clauck marketplace <tag>")
     print(f"  tags: {', '.join(sorted(all_tags))}")
+
+
+def cmd_marketplace_info(name: str) -> None:
+    index_file = MARKETPLACE_DIR / "index.json"
+    if not index_file.exists():
+        die("marketplace not found — run the installer to populate it")
+    index = json.loads(index_file.read_text())
+    match = [j for j in index.get("jobs", []) if j["name"] == name]
+    if not match:
+        available = ", ".join(j["name"] for j in index.get("jobs", []))
+        die(f"no marketplace job '{name}'. Available: {available}")
+    j = match[0]
+
+    catalog_ver = j.get("version", "")
+    dst = JOBS_DIR / f"{j['name']}.md"
+    installed = dst.exists()
+    installed_ver = _parse_frontmatter_version(dst) if installed else ""
+    update_available = installed and catalog_ver and installed_ver != catalog_ver
+
+    ver_str = f"  (v{catalog_ver})" if catalog_ver else ""
+    print(f"\n  {j['name']}{ver_str}")
+    print(f"  {j.get('one_line', '')}")
+    print()
+    cost = j.get("cost_per_run_usd_approx", "?")
+    monthly = j.get("monthly_cost_usd_approx", "?")
+    runs = j.get("runs_per_month_approx", "?")
+    print(f"  schedule:  {j.get('schedule', 'ad-hoc')}")
+    print(f"  cost:      ~${cost}/run  |  ~${monthly}/month ({runs} runs/month)")
+    tags = j.get("tags", [])
+    if tags:
+        print(f"  tags:      {', '.join(tags)}")
+    requires = j.get("requires", {})
+    mcps = requires.get("mcps")
+    if mcps:
+        print(f"  requires:  {mcps}")
+    setup = requires.get("setup", [])
+    if setup:
+        print(f"  customize:")
+        for step in setup:
+            print(f"    - {step}")
+    if installed:
+        if update_available:
+            print(f"\n  status:  installed (v{installed_ver}) — update available (v{catalog_ver})")
+            print(f"  upgrade: clauck install {name} --update")
+        else:
+            iv = f" (v{installed_ver})" if installed_ver else ""
+            print(f"\n  status:  installed{iv} — up to date")
+    else:
+        print(f"\n  install: clauck install {name}")
+
+
+def cmd_marketplace_search(query: str) -> None:
+    index_file = MARKETPLACE_DIR / "index.json"
+    if not index_file.exists():
+        die("marketplace not found — run the installer to populate it")
+    if not query.strip():
+        die("usage: clauck marketplace search <query>")
+    index = json.loads(index_file.read_text())
+    q = query.lower()
+    jobs = [
+        j for j in index.get("jobs", [])
+        if q in j.get("name", "").lower()
+        or q in j.get("one_line", "").lower()
+        or q in " ".join(j.get("tags", [])).lower()
+    ]
+    if not jobs:
+        print(f"  no marketplace jobs matching '{query}'")
+        all_tags: set = set()
+        for j in index.get("jobs", []):
+            all_tags.update(j.get("tags", []))
+        print(f"  browse by tag: clauck marketplace <tag>")
+        print(f"  tags: {', '.join(sorted(all_tags))}")
+        return
+    print(f"  {len(jobs)} result(s) for '{query}':\n")
+    for j in jobs:
+        installed = (JOBS_DIR / f"{j['name']}.md").exists()
+        marker = " [installed]" if installed else ""
+        cost = j.get("cost_per_run_usd_approx", "?")
+        print(f"    {j['name']:<23} ~${cost}/run  {j.get('schedule', '')}{marker}")
+        print(f"      {j.get('one_line', '')}")
+    print(f"\n  details: clauck marketplace info <name>")
 
 
 def _parse_frontmatter_version(path: Path) -> str:
@@ -2163,6 +2246,10 @@ def main() -> None:
     elif cmd == "marketplace":
         if rest and rest[0] == "updates":
             cmd_marketplace_updates()
+        elif rest and rest[0] == "info" and len(rest) >= 2:
+            cmd_marketplace_info(rest[1])
+        elif rest and rest[0] == "search":
+            cmd_marketplace_search(" ".join(rest[1:]))
         else:
             cmd_marketplace(filter_tag=rest[0] if rest else "")
     elif cmd == "install" and rest:

--- a/skill/clauck/SKILL.md
+++ b/skill/clauck/SKILL.md
@@ -30,7 +30,8 @@ When the user asks something in this list, follow the playbook — don't improvi
 | User intent | Playbook |
 |---|---|
 | "What's installed / what jobs do I have?" | `cat ~/.clauck/.manifest.json \| python3 -m json.tool`. Summarize each job in one line (name, cron/triggers, purpose). Also note the installed version from `~/.clauck/.version`. |
-| "What can I add?" / "Show me the marketplace" | Read `~/.claude/skills/clauck/marketplace/index.json`. Present jobs as a compact list: `<name> (<category>) — <one_line>. Costs ~$X/mo. Requires: <mcps>`. If user mentions a category/tag, filter first. |
+| "What can I add?" / "Show me the marketplace" | Run `clauck marketplace` to browse by category, or `clauck marketplace <tag>` to filter. For full details on a specific job: `clauck marketplace info <name>`. |
+| "Find jobs for X" / "Is there a job that does Y?" | Run `clauck marketplace search <query>` — searches job name, description, and tags. |
 | "Install [marketplace job]" | See **Installing from the marketplace** below. Copy the `.md`, walk the user through any `CUSTOMIZE BEFORE INSTALLING` blocks, then ad-hoc fire to verify. |
 | "Add a new scheduled job for …" | See **Designing a new job** below. Elicit cron/trigger, budget, destination, then write the `.md`, ad-hoc fire, confirm. |
 | "Make this job depend on / use output from [other job]" | Add `producers: [{name: other-job}]` to frontmatter. Check manifest for cycle errors within 60s. See **Pipelines** below. |


### PR DESCRIPTION
## Motivation

`clauck marketplace` lists all jobs in one shot, which works today (7 jobs) but won't scale. Issue #11 calls this out specifically. Two user-facing gaps it creates right now:

1. **No way to get full details before installing.** The list view shows a one-liner and cost — not enough to know if a job fits your workflow, what MCPs it needs, or what you'll have to configure. Users either install blindly or read raw JSON.
2. **No way to find jobs by keyword.** The existing `clauck marketplace <tag>` filtering requires knowing the exact tag. A user asking "is there a job for email?" can't discover `inbox-zero-assist` unless they already know the tag is `gmail`.

## Before / After

**Before:**
```
clauck marketplace            # dumps all 7 jobs
clauck marketplace gmail      # exact tag match only; no description of what you're getting
```

**After:**
```
clauck marketplace info inbox-zero-assist
  inbox-zero-assist  (v1.0.0)
  End-of-day scan of Gmail threads unread for 48h+. Suggests actions in a local file. Never sends.

  schedule:  weekdays at 22:00 UTC (configurable)
  cost:      ~$0.12/run  |  ~$2.64/month (22 runs/month)
  tags:      productivity, gmail, email, triage, inbox-zero, daily
  requires:  Gmail
  customize:
    - Optionally adjust cron time to match your end of workday.
    - Optionally narrow to specific Gmail labels.

  install: clauck install inbox-zero-assist

clauck marketplace search "email"
  1 result(s) for 'email':

    inbox-zero-assist       ~$0.12/run  weekdays at 22:00 UTC (configurable)
      End-of-day scan of Gmail threads unread for 48h+. Suggests actions in a local file. Never sends.

  details: clauck marketplace info <name>
```

## Cost-to-Value

- 87 lines added to `lib/clauck`, 2 lines updated in `SKILL.md`. No new files. No schema changes.
- Zero behavior change for existing commands (`clauck marketplace`, `clauck marketplace <tag>`, `clauck marketplace updates`, `clauck install`).
- Addresses 2 of 3 goals from issue #11 (navigation + discovery). The third goal (module-aware folder structure) depends on marketplace module-format jobs existing — none do yet.

## Confidence-to-Impact

- `cmd_marketplace_info` and `cmd_marketplace_search` are pure read paths: load index.json, filter, print. No state mutation, no network calls.
- Both new functions share the same `_parse_frontmatter_version` logic already used by `cmd_marketplace_updates` for the "installed / update available" status display.
- All CLAUDE.md checks pass: `bash -n`, Python AST parse, JSON parse, dry-run install.

## Validation Steps

```bash
# Install from this branch, then:

# Full details for a job
clauck marketplace info morning-brief

# Search by keyword (not just exact tag)
clauck marketplace search "email"
clauck marketplace search "git"
clauck marketplace search "github"

# Zero-result case
clauck marketplace search "nonexistent"
# → shows available tags, suggests clauck marketplace <tag>

# Verify no regression on existing commands
clauck marketplace
clauck marketplace productivity
clauck marketplace updates
```

## Falsifiability

If search results for common keywords miss obvious matches (e.g., `clauck marketplace search "pr"` doesn't return `github-pr-digest`), the field coverage in `cmd_marketplace_search` is incomplete and needs to expand to additional index fields.

## Related

Partially closes [#11](https://github.com/CoreyRDean/clauck/issues/11).