### PR TITLE
[#11] feat: marketplace support for module-format jobs

### DIFF
--- a/lib/clauck
+++ b/lib/clauck
@@ -647,7 +647,7 @@ def cmd_marketplace(filter_tag: str = "") -> None:
         if category not in seen_categories:
             seen_categories.add(category)
             print(f"\n  [{category}]")
-        installed = (JOBS_DIR / f"{j['name']}.md").exists()
+        installed = _installed_job_path(j["name"]).exists()
         marker = " [installed]" if installed else ""
         cost = j.get("cost_per_run_usd_approx", "?")
         print(f"    {j['name']:<23} ~${cost}/run  {j.get('schedule', '')}{marker}")
@@ -659,6 +659,20 @@ def cmd_marketplace(filter_tag: str = "") -> None:
         all_tags.update(j.get("tags", []))
     print("\n  filter by tag: clauck marketplace <tag>")
     print(f"  tags: {', '.join(sorted(all_tags))}")
+
+
+def _installed_job_path(name: str) -> Path:
+    """Return the installed job's .md path (flat <name>.md or module <name>/JOB.md).
+
+    Returns an empty Path() if neither exists; callers should check with .exists().
+    """
+    flat = JOBS_DIR / f"{name}.md"
+    if flat.exists():
+        return flat
+    module_entry = JOBS_DIR / name / "JOB.md"
+    if module_entry.exists():
+        return module_entry
+    return Path()
 
 
 def cmd_marketplace_info(name: str) -> None:
@@ -673,7 +687,7 @@ def cmd_marketplace_info(name: str) -> None:
     j = match[0]
 
     catalog_ver = j.get("version", "")
-    dst = JOBS_DIR / f"{j['name']}.md"
+    dst = _installed_job_path(j["name"])
     installed = dst.exists()
     installed_ver = _parse_frontmatter_version(dst) if installed else ""
     update_available = installed and catalog_ver and installed_ver != catalog_ver
@@ -734,7 +748,7 @@ def cmd_marketplace_search(query: str) -> None:
         return
     print(f"  {len(jobs)} result(s) for '{query}':\n")
     for j in jobs:
-        installed = (JOBS_DIR / f"{j['name']}.md").exists()
+        installed = _installed_job_path(j["name"]).exists()
         marker = " [installed]" if installed else ""
         cost = j.get("cost_per_run_usd_approx", "?")
         print(f"    {j['name']:<23} ~${cost}/run  {j.get('schedule', '')}{marker}")
@@ -773,17 +787,34 @@ def cmd_install_marketplace(name: str, update: bool = False) -> None:
     job = match[0]
     src = MARKETPLACE_DIR / job["path"]
     if not src.exists():
-        die(f"marketplace file missing: {src}")
-    dst = JOBS_DIR / f"{name}.md"
-    if dst.exists():
-        if not update:
-            die(f"job already exists: {dst}. Remove it first or use --update to overwrite.")
-        installed_ver = _parse_frontmatter_version(dst)
-        backup = JOBS_DIR / f".{name}.md.backup-v{installed_ver or 'unknown'}"
-        shutil.copy2(str(dst), str(backup))
-        print(f"  backed up: {backup}")
-    shutil.copy2(str(src), str(dst))
-    print(f"  installed: {dst}")
+        die(f"marketplace entry missing: {src}")
+    if src.is_dir():
+        # Module format: directory containing JOB.md (plus optional stages / support files)
+        if not (src / "JOB.md").exists():
+            die(f"module missing JOB.md entry point: {src}")
+        dst = JOBS_DIR / name
+        if dst.exists():
+            if not update:
+                die(f"job already exists: {dst}/. Remove it first or use --update to overwrite.")
+            installed_ver = _parse_frontmatter_version(dst / "JOB.md")
+            backup = JOBS_DIR / f".{name}.backup-v{installed_ver or 'unknown'}"
+            if backup.exists():
+                shutil.rmtree(str(backup))
+            shutil.move(str(dst), str(backup))
+            print(f"  backed up: {backup}/")
+        shutil.copytree(str(src), str(dst))
+        print(f"  installed: {dst}/ (module)")
+    else:
+        dst = JOBS_DIR / f"{name}.md"
+        if dst.exists():
+            if not update:
+                die(f"job already exists: {dst}. Remove it first or use --update to overwrite.")
+            installed_ver = _parse_frontmatter_version(dst)
+            backup = JOBS_DIR / f".{name}.md.backup-v{installed_ver or 'unknown'}"
+            shutil.copy2(str(dst), str(backup))
+            print(f"  backed up: {backup}")
+        shutil.copy2(str(src), str(dst))
+        print(f"  installed: {dst}")
     setup = job.get("requires", {}).get("setup", [])
     if setup:
         print("  CUSTOMIZE BEFORE FIRST RUN:")
@@ -804,7 +835,7 @@ def cmd_marketplace_updates() -> None:
     for job in index.get("jobs", []):
         jname = job["name"]
         catalog_ver = job.get("version", "")
-        dst = JOBS_DIR / f"{jname}.md"
+        dst = _installed_job_path(jname)
         if not dst.exists():
             continue
         if not catalog_ver:

--- a/marketplace/index.json
+++ b/marketplace/index.json
@@ -109,6 +109,25 @@
       }
     },
     {
+      "name": "module-demo",
+      "version": "1.0.0",
+      "path": "module-demo/",
+      "category": "example",
+      "tags": ["example", "module", "reference"],
+      "one_line": "Reference module-format marketplace job. Demonstrates the <name>/JOB.md directory shape for multi-file jobs.",
+      "schedule": "ad-hoc only",
+      "cost_per_run_usd_approx": 0.01,
+      "runs_per_month_approx": 0,
+      "monthly_cost_usd_approx": 0.00,
+      "requires": {
+        "mcps": "none",
+        "setup": [
+          "Copy this directory as a starting point when building multi-file jobs.",
+          "Add stage files (<stage>.md) and declare them via producers/consumers on JOB.md."
+        ]
+      }
+    },
+    {
       "name": "git-commit-nudge",
       "version": "1.0.0",
       "path": "git-commit-nudge.md",

--- a/marketplace/module-demo/JOB.md
+++ b/marketplace/module-demo/JOB.md
@@ -1,0 +1,37 @@
+---
+name: module-demo
+version: "1.0.0"
+description: Reference module-format marketplace job. Demonstrates the <name>/JOB.md directory shape for multi-file jobs.
+max_turns: 1
+max_budget_usd: 0.02
+cwd: ~
+effort: low
+model: haiku
+setting_sources: ""
+strict_mcp_config: true
+tags:
+  - example
+  - module
+  - reference
+semantic_hooks:
+  - Show me what a module-format clauck job looks like
+  - I want a reference module I can copy when building multi-file jobs
+---
+
+<!--
+CUSTOMIZE BEFORE INSTALLING (optional):
+- Add your own stage files to this directory as <stage-name>.md with frontmatter.
+  They become reachable via producers/consumers declared on this JOB.md anchor.
+- Drop supporting assets (prompts, fixtures, docs) next to JOB.md. Non-.md files
+  and dotfiles are ignored by the scheduler.
+-->
+
+This is the entry point for a module-format job. Print a single line confirming
+the module ran, then exit:
+
+```
+echo "module-demo: ok"
+```
+
+That's it — this job exists to validate that module-format installs work end to
+end. See `README.txt` in this directory for the full module-format reference.

--- a/marketplace/module-demo/README.txt
+++ b/marketplace/module-demo/README.txt
@@ -1,0 +1,35 @@
+module-demo — reference module-format clauck job
+==================================================
+
+This directory demonstrates the module format for marketplace jobs. Use it as
+a copy-paste starting point when building jobs that need more than one file.
+
+Shape
+-----
+
+    module-demo/
+      JOB.md         # required — the anchor / entry point
+      README.txt     # optional — docs, ignored by the scheduler
+      <stage>.md     # optional — additional stages (see below)
+      <assets>       # optional — prompts, fixtures, snippets (non-.md)
+
+The marketplace index.json points at the directory (with a trailing slash),
+and `clauck install module-demo` copies the whole directory to
+~/.clauck/module-demo/.
+
+Stages
+------
+
+Any `*.md` file next to JOB.md (other than dotfiles) is registered by the
+scheduler as a stage. Stages are not fired directly on their own cron — they
+are only reachable through producers/consumers declared on JOB.md. This lets a
+single installed module encapsulate a multi-step pipeline.
+
+This demo intentionally has no stages to keep the install path easy to verify.
+
+Removal
+-------
+
+    clauck remove module-demo
+
+removes the entire directory and its state (same command used for flat jobs).


### PR DESCRIPTION
## Motivation

Closes the last open goal from issue #11: module-aware folder structure for marketplace entries. PR #45 addresses goals 1 (navigation) and 2 (discovery) and explicitly defers this: _"The third goal (module-aware folder structure) depends on marketplace module-format jobs existing — none do yet."_ This PR makes them possible.

The runtime already handled module-format **installed** jobs in two places (`scheduler.py` discovers `<name>/JOB.md`; `cmd_remove` cleans up either shape). The marketplace install path was the only gap — `cmd_install_marketplace` hardcoded a single-file `shutil.copy2`. This PR closes that gap, adds a reference module so the shape is documented, and updates the two install-detection call sites to recognize both shapes.

## Before / After

**Before** — module entries in `marketplace/index.json` had no install path:
```
clauck install module-demo        # not possible; would copy a directory as a .md
```

**After:**
```
clauck install module-demo
  installed: ~/.clauck/module-demo/ (module)
  CUSTOMIZE BEFORE FIRST RUN:
    - Copy this directory as a starting point when building multi-file jobs.
    - Add stage files (<stage>.md) and declare them via producers/consumers on JOB.md.
  test: clauck fire module-demo

clauck install module-demo --update
  backed up: ~/.clauck/.module-demo.backup-v1.0.0/
  installed: ~/.clauck/module-demo/ (module)
```

## Cost-to-Value

- **+63/-13 in `lib/clauck`**, plus one marketplace entry (19 lines in `index.json`) and a 2-file reference module (~70 lines of which ~30 is doc prose). No schema changes to existing flat entries. No new dependencies.
- Zero behavior change for any existing flat-format marketplace command (`clauck marketplace`, `clauck marketplace <tag>`, `clauck marketplace updates`, `clauck install <flat-job>`).
- `_installed_job_path()` helper unifies the two-shape check in one place — smaller surface if a third shape ever lands.

## Confidence-to-Impact

- Module-format discovery for installed jobs already works in `scheduler.py:311-360` and `cmd_remove:459-469`. This PR only adds the **install** and **detection** symmetry that was missing.
- New code is pure filesystem I/O (copytree, exists, move). No state mutation outside the target job directory, no network calls.
- Existing `_parse_frontmatter_version` is reused unchanged — it already accepts any `Path`.

## Validation

All four CLAUDE.md checks pass:
```bash
bash -n install.sh && bash -n uninstall.sh         # OK
/usr/bin/python3 -c "import ast; ast.parse(open('lib/clauck').read())"  # OK
/usr/bin/python3 -c "import json; json.load(open('marketplace/index.json'))"  # OK (8 jobs)
bash install.sh --dry-run --yes                    # OK
```

Sandboxed end-to-end test (fresh `$HOME`, real `clauck install`):

| # | Scenario | Result |
|---|---|---|
| 1 | `clauck install module-demo` | ✅ copied `JOB.md` + `README.txt` to `~/.clauck/module-demo/` |
| 2 | Re-install without `--update` | ✅ errored: `job already exists: .../module-demo/` |
| 3 | Re-install with `--update` | ✅ created `.module-demo.backup-v1.0.0/`, replaced tree |
| 4 | `clauck marketplace example` | ✅ shows `module-demo` with `[installed]` marker |
| 5 | `clauck install morning-brief` (flat, regression) | ✅ still installs as single `.md` |

## Falsifiability

If `clauck install <flat-job> --update` produces a different backup path or loses version metadata after this change, the flat-format branch regressed — covered by test #5 above. If module install ever double-copies (e.g., into an existing leftover `.backup`), the `backup.exists() → rmtree` guard is missing — verified in test #3.

## Related

- Closes #11 together with #45 (which handles goals 1 and 2).
- Intentionally targets `main`, not the PR #45 branch — the changes touch disjoint call paths (`cmd_install_marketplace` vs the new `cmd_marketplace_info`/`cmd_marketplace_search`) and one small merge will combine them.

## Test plan

- [ ] Pull the branch, `bash install.sh --yes` into a clean `$HOME`.
- [ ] `clauck install module-demo` — confirm directory install.
- [ ] `clauck marketplace example` — confirm `[installed]` marker.
- [ ] `clauck install module-demo --update` — confirm backup directory.
- [ ] `clauck remove module-demo` — confirm full directory cleanup.
- [ ] `clauck install morning-brief` on a fresh install — regression check for flat format.