### PR TITLE
fix: exclude prompt.md from job discovery

### DIFF
--- a/lib/scheduler.py
+++ b/lib/scheduler.py
@@ -60,7 +60,7 @@ def _open_dispatch_log():
 
 
 # Files with these stems are skipped even if they live in jobs dir.
-RESERVED_STEMS = {"scheduler", "run-job", "trigger-job", "update-check"}
+RESERVED_STEMS = {"scheduler", "run-job", "trigger-job", "update-check", "prompt"}
 
 
 # ---------- frontmatter ----------


### PR DESCRIPTION
## Motivation

\`~/.clauck/prompt.md\` is the global system prompt appended to every job's run — an internal runtime artifact, not a scheduled job. But it's currently being treated like one:

\`\`\`
$ /usr/bin/python3 -c "import json; m=json.load(open('$HOME/.clauck/.manifest.json')); print([j['name'] for j in m['jobs']])"
['clauck-work', 'daily-verify', 'heartbeat', 'prompt', 'intent-miner', 'pe-pipeline']
                                                ^^^^^^ should not be here
\`\`\`

This surfaces as a spurious row in \`clauck list\` and \`clauck next\`.

## Root cause

\`lib/scheduler.py:discover_jobs()\` globs \`*.md\` in \`JOBS_DIR\` and filters by dotfile prefix + \`RESERVED_STEMS\`. The reserved set covered the four runtime scripts but missed the one non-script file the installer lays down next to them:

\`\`\`python
RESERVED_STEMS = {"scheduler", "run-job", "trigger-job", "update-check"}
\`\`\`

\`install.sh:317\` places \`~/.clauck/prompt.md\` alongside those scripts, and \`run-job.sh:43\` reads it as \`GLOBAL_PROMPT\` — so it's always on disk, always gets globbed, and always becomes a fake job.

## Fix

Add \`"prompt"\` to \`RESERVED_STEMS\`. One character's worth of actual logic change.

## Cost-to-Value

- **+1/-1**, one file (\`lib/scheduler.py\`).
- Zero risk to existing jobs: the filter already existed; this just extends its set. Any user who somehow named a real job \`prompt\` was already at risk of colliding with the global prompt file; now that collision is explicit and the runtime won't load \`prompt.md\` as a job.

## Validation

Sandboxed \`discover_jobs()\` with a fake \`JOBS_DIR\` containing both \`prompt.md\` and a real job file:

\`\`\`
JOBS_DIR: /tmp/.../\.clauck
RESERVED: {'prompt', 'update-check', 'trigger-job', 'run-job', 'scheduler'}
discovered job names: ['realjob']
PASS
\`\`\`

AST parse and \`bash -n\` on install/uninstall both pass.

## Falsifiability

If a user has a legitimate job they named \`prompt\` (unlikely, since the installer would overwrite it on the next update), it would stop being discovered. Acceptable: the global prompt file is a first-class runtime artifact, it owns the stem.

## Test plan

- [ ] After merging, next scheduler tick (60s) rewrites \`~/.clauck/.manifest.json\` without a \`prompt\` entry.
- [ ] \`clauck list\` and \`clauck next\` no longer show \`prompt\`.
- [ ] All other registered jobs remain intact with their cron/trigger metadata.