### PR TITLE
[#50] feat: clauck logs --show — print log content inline; expose paths in summary

### DIFF
--- a/lib/clauck
+++ b/lib/clauck
@@ -11,7 +11,8 @@ Usage:
     clauck edit <name>                   Open job prompt in your editor (flat or module)
     clauck edit <module>/<stage>         Edit module internal stage file
     clauck remove <name>                 Delete a job + its state (also: delete, rm)
-    clauck logs <name> [--last N]        Show recent logs
+    clauck logs <name> [--last N]        Show recent logs (paths + summary)
+    clauck logs <name> --show [N]        Print content of Nth most recent log (default: 1)
     clauck marketplace                    Browse pre-made jobs
     clauck marketplace info <name>        Show full details for a marketplace job
     clauck marketplace search <query>     Search marketplace by keyword
@@ -597,14 +598,21 @@ def cmd_edit(name: str) -> None:
         print(f"  reset runs counter for: {canonical_name}")
 
 
-def cmd_logs(name: str, last: int = 5) -> None:
+def cmd_logs(name: str, last: int = 5, show: int = 0) -> None:
+    import re as _re
     pattern = f"{name}-[0-9]*.log"
     logs = sorted(JOBS_DIR.glob(pattern), key=lambda p: p.stat().st_mtime, reverse=True)
     if not logs:
         print(f"  no logs found for: {name}")
         return
+    if show:
+        idx = show - 1
+        if idx >= len(logs):
+            print(f"  only {len(logs)} log(s) available for: {name}")
+            return
+        print(logs[idx].read_text(), end="")
+        return
     for log in logs[:last]:
-        # Extract key info from log
         text = log.read_text()
         exit_line = ""
         cost = ""
@@ -612,12 +620,11 @@ def cmd_logs(name: str, last: int = 5) -> None:
             if "exit_code=" in line:
                 exit_line = line.strip()
             if '"total_cost_usd"' in line:
-                import re
-                m = re.search(r'"total_cost_usd":([\d.]+)', line)
+                m = _re.search(r'"total_cost_usd":([\d.]+)', line)
                 if m:
                     cost = f"${float(m.group(1)):.4f}"
         ts = log.stem.split("-", 1)[1] if "-" in log.stem else "?"
-        print(f"  {ts:<30} {exit_line:<25} {cost}")
+        print(f"  {ts:<30} {exit_line:<25} {cost:<10}  {log}")
 
 
 def cmd_marketplace(filter_tag: str = "") -> None:
@@ -2272,12 +2279,22 @@ def main() -> None:
         cmd_remove(rest[0])
     elif cmd == "logs" and rest:
         last = 5
+        show = 0
         if "--last" in rest:
             idx = rest.index("--last")
             if idx + 1 < len(rest):
                 last = int(rest[idx + 1])
             rest = [r for i, r in enumerate(rest) if i != idx and i != idx + 1]
-        cmd_logs(rest[0], last)
+        if "--show" in rest:
+            idx = rest.index("--show")
+            # Optional N after --show; default to 1 (most recent)
+            if idx + 1 < len(rest) and rest[idx + 1].isdigit():
+                show = int(rest[idx + 1])
+                rest = [r for i, r in enumerate(rest) if i != idx and i != idx + 1]
+            else:
+                show = 1
+                rest = [r for i, r in enumerate(rest) if i != idx]
+        cmd_logs(rest[0], last, show)
     elif cmd == "marketplace":
         if rest and rest[0] == "updates":
             cmd_marketplace_updates()

--- a/lib/clauck
+++ b/lib/clauck
@@ -719,7 +719,7 @@ def cmd_marketplace_info(name: str) -> None:
         print(f"  requires:  {mcps}")
     setup = requires.get("setup", [])
     if setup:
-        print(f"  customize:")
+        print("  customize:")
         for step in setup:
             print(f"    - {step}")
     if installed:
@@ -752,7 +752,7 @@ def cmd_marketplace_search(query: str) -> None:
         all_tags: set = set()
         for j in index.get("jobs", []):
             all_tags.update(j.get("tags", []))
-        print(f"  browse by tag: clauck marketplace <tag>")
+        print("  browse by tag: clauck marketplace <tag>")
         print(f"  tags: {', '.join(sorted(all_tags))}")
         return
     print(f"  {len(jobs)} result(s) for '{query}':\n")
@@ -762,7 +762,7 @@ def cmd_marketplace_search(query: str) -> None:
         cost = j.get("cost_per_run_usd_approx", "?")
         print(f"    {j['name']:<23} ~${cost}/run  {j.get('schedule', '')}{marker}")
         print(f"      {j.get('one_line', '')}")
-    print(f"\n  details: clauck marketplace info <name>")
+    print("\n  details: clauck marketplace info <name>")
 
 
 def _parse_frontmatter_version(path: Path) -> str:


### PR DESCRIPTION
## Closes #50

## Motivation

`clauck logs <name>` shows a summary table (timestamp, exit_code, cost) but never reveals where the log files are, and has no in-terminal way to read what a job actually did. The user's next move after seeing a failure is to either bail to the filesystem or give up. This PR closes that loop.

## Before / After

**Before:**
```
$ clauck logs heartbeat
  20260417T020007Z-1706   --- exit_code=0 ===       $0.0123
  20260416T230036Z-21219  --- exit_code=0 ===       $0.0118
```
Path unknown. Must manually find the log file.

**After:**
```
$ clauck logs heartbeat
  20260417T020007Z-1706   --- exit_code=0 ===   $0.0123     /Users/me/.clauck/heartbeat-20260417T020007Z-1706.log
  20260416T230036Z-21219  --- exit_code=0 ===   $0.0118     /Users/me/.clauck/heartbeat-20260416T230036Z-21219.log
```

**New `--show [N]` flag:**
```
$ clauck logs heartbeat --show        # prints most recent log content
$ clauck logs heartbeat --show 2      # prints second most recent
$ clauck logs my-job --show | grep "error"   # composable with other tools
```

## Cost / Value

- 24 lines added, 7 removed — net +17 in `lib/clauck`
- Zero new dependencies
- Backward compatible: `--last N` still works; summary rows gain a path column
- Closes the most common post-failure workflow (summary → read log) without filesystem navigation

## Confidence / Risk

- Path addition is purely additive output — no existing callers affected
- `--show` parsing mirrors the existing `--last` pattern exactly
- Syntax and compile pass in worktree; zero new ruff-triggering patterns

## Validation Steps

```bash
# 1. Syntax
python3 -c "import ast; ast.parse(open('lib/clauck').read())" && echo OK

# 2. Summary now includes path
clauck logs heartbeat
# → each row ends with the absolute .log path

# 3. --show prints content
clauck logs heartbeat --show | head -5
# → log header lines (=== scheduled-job start: ... ===)

# 4. --show 2 prints second most recent
clauck logs heartbeat --show 2 | head -3

# 5. Boundary: --show N > available log count
# → "only X log(s) available for: heartbeat"

# 6. Backward compat: --last N still works unchanged
clauck logs heartbeat --last 3
```