### PR TITLE
[#59] feat: mcp server post-launch gap — log content, next fires, marketplace info/install

### DIFF
--- a/lib/clauck-mcp
+++ b/lib/clauck-mcp
@@ -18,7 +18,7 @@ from pathlib import Path
 HOME = Path.home()
 _CLAUCK_FALLBACK = HOME / ".local" / "bin" / "clauck"
 
-SERVER_INFO = {"name": "clauck", "version": "1.0.0"}
+SERVER_INFO = {"name": "clauck", "version": "1.1.0"}
 
 TOOLS = [
     {
@@ -61,14 +61,25 @@ TOOLS = [
     },
     {
         "name": "get_logs",
-        "description": "Fetch recent log output for a clauck job.",
+        "description": (
+            "Fetch recent log metadata for a clauck job. "
+            "Pass `show` to include the full content of the Nth most-recent log inline "
+            "(e.g. show=1 for the latest run's output)."
+        ),
         "inputSchema": {
             "type": "object",
             "properties": {
                 "name": {"type": "string", "description": "Job name"},
                 "last": {
                     "type": "integer",
-                    "description": "Number of recent runs to show (default: 3, max: 20)",
+                    "description": "Number of recent runs to list (default: 5, max: 20)",
+                },
+                "show": {
+                    "type": "integer",
+                    "description": (
+                        "Print the full content of the Nth most-recent log (1 = latest). "
+                        "Omit to return metadata only."
+                    ),
                 },
             },
             "required": ["name"],
@@ -130,6 +141,51 @@ TOOLS = [
             "required": [],
         },
     },
+    {
+        "name": "next_fires",
+        "description": (
+            "Show when each job is next scheduled to fire. "
+            "Returns a table with job names, cron expressions, and human-readable "
+            "next-fire times (e.g. 'in 55m', 'tomorrow 09:00')."
+        ),
+        "inputSchema": {"type": "object", "properties": {}, "required": []},
+    },
+    {
+        "name": "marketplace_info",
+        "description": (
+            "Get full details for a clauck marketplace job before installing: "
+            "version, schedule, estimated cost per run, required MCPs, "
+            "and customization steps."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Marketplace job name (from marketplace_list)",
+                },
+            },
+            "required": ["name"],
+        },
+    },
+    {
+        "name": "install_job",
+        "description": (
+            "Install a job from the clauck marketplace. "
+            "After installing, the job appears in list_jobs and fires on its schedule. "
+            "Use marketplace_info first to review the job before installing."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Marketplace job name to install",
+                },
+            },
+            "required": ["name"],
+        },
+    },
 ]
 
 
@@ -167,6 +223,8 @@ def _dispatch(name: str, args: dict) -> str:
         cmd = ["logs", args["name"]]
         if args.get("last"):
             cmd += ["--last", str(int(args["last"]))]
+        if args.get("show"):
+            cmd += ["--show", str(int(args["show"]))]
         return _run(*cmd)
     if name == "inspect_job":
         return _run("inspect", args["name"])
@@ -180,6 +238,12 @@ def _dispatch(name: str, args: dict) -> str:
         if tag:
             cmd.append(tag)
         return _run(*cmd)
+    if name == "next_fires":
+        return _run("next")
+    if name == "marketplace_info":
+        return _run("marketplace", "info", args["name"])
+    if name == "install_job":
+        return _run("install", args["name"])
     return f"error: unknown tool '{name}'"
 
 


### PR DESCRIPTION
## Closes #59

## Motivation

The `clauck mcp` server landed in v1.5.7 with 8 tools, but 4 high-value CLI capabilities were left unconnected. Claude Desktop users can list and fire jobs, but they hit dead ends on the most natural follow-up questions: "what happened in that run?", "when does it next fire?", "what's the heartbeat job in the marketplace?", "install it for me."

This PR fills those gaps. No new logic is added — each new tool is a thin wrapper over an existing CLI command, matching the exact pattern of every existing MCP tool.

## Before / After

| User question | Before | After |
|---|---|---|
| "What did the last heartbeat run output?" | Dead end — `get_logs` returns file paths, no content | `get_logs` with `show: 1` returns the log content inline |
| "When does daily-verify next fire?" | No tool available | `next_fires` returns the full schedule table |
| "Tell me about the pe-pipeline marketplace job" | Not possible | `marketplace_info` returns version, cost, MCPs, customization steps |
| "Install the heartbeat job" | Not possible | `install_job` runs `clauck install heartbeat` |

## Cost-to-Value Proposition

67 lines added, 3 changed across one file. Zero new dependencies. No behavior change for the existing 8 tools. The 4 new tools close a workflow gap that blocked every discovery and observability use case in Claude Desktop.

## Confidence-to-Impact Proposition

Each new dispatch branch follows the identical pattern as existing branches — `_run("command", args["param"])`. The only new logic is the `show` param on `get_logs`, which appends `--show <N>` to the existing `clauck logs` call. All CLI commands being wrapped exist and are tested in the installed binary.

All syntax checks pass (ast.parse + bash -n).

## Validation Steps

```bash
# 1. Syntax check
python3 -c "import ast; ast.parse(open('lib/clauck-mcp').read()); print('ok')"

# 2. Confirm 12 tools are registered
python3 -c "
import subprocess, json
msg = json.dumps({'jsonrpc':'2.0','id':1,'method':'tools/list','params':{}})
r = subprocess.run(['python3', 'lib/clauck-mcp'], input=
    json.dumps({'jsonrpc':'2.0','id':0,'method':'initialize','params':{}}) + '\n' +
    msg + '\n',
    capture_output=True, text=True)
for line in r.stdout.strip().splitlines():
    obj = json.loads(line)
    if obj.get('id') == 1:
        names = [t['name'] for t in obj['result']['tools']]
        print(f'{len(names)} tools:', names)
"

# 3. Smoke-test new tools via installed clauck (after install.sh redeploy)
clauck next
clauck logs heartbeat --show 1
clauck marketplace info heartbeat
```

## External Artifacts

- Issue: https://github.com/CoreyRDean/clauck/issues/59