### PR TITLE
[#61] feat: clauck validate — job schema validation

### DIFF
--- a/lib/clauck
+++ b/lib/clauck
@@ -1392,7 +1392,7 @@ def cmd_validate(names: "list[str]", all_jobs: bool = False) -> None:
         n_warnings += nw
 
         if ne == 0 and nw == 0:
-            print(f"  \033[32m✓ all checks passed\033[0m")
+            print("  \033[32m✓ all checks passed\033[0m")
         else:
             parts = []
             if ne:

--- a/lib/clauck
+++ b/lib/clauck
@@ -24,6 +24,8 @@ Usage:
     clauck config [set <key> <value>]    Show or edit config
                                          (e.g. clauck config set notifications true)
     clauck add <path> [--name N] [--when "schedule"]  Import a file as a job
+    clauck validate <name> [<name2> …]   Validate a job's frontmatter and config
+    clauck validate --all                Validate all installed jobs
     clauck inspect <name>                 Inspect a job's config and DAG
     clauck doctor [--fix] [--unsafe] [-i] [<context>]   Diagnose system health
                                          (default: --dry --safe — analysis only, no mutations)
@@ -69,7 +71,7 @@ KNOWN_COMMANDS = {
     "list", "status", "fire", "pause", "resume", "edit", "logs",
     "marketplace", "install", "update", "uninstall", "config", "version",
     "doctor", "report", "peek", "work", "mcp",
-    "add", "inspect", "remove", "delete", "rm", "next",
+    "add", "validate", "inspect", "remove", "delete", "rm", "next",
     "-h", "--help", "help",
 }
 
@@ -1139,6 +1141,277 @@ def cmd_add(path: str, name: str = "", when: str = "") -> None:
         print(f"  added: {job_name}")
     print(f"  path: {dst}")
     print(f"  test: clauck fire {job_name}")
+
+
+# ── validate helpers (mirrors scheduler.py subset; duplicated to keep clauck standalone) ──
+
+_KNOWN_FM_FIELDS: "set[str]" = {
+    "name", "description", "cron", "max_turns", "max_budget_usd",
+    "cwd", "effort", "model", "setting_sources", "strict_mcp_config",
+    "debounce_seconds", "disabled", "run_once", "max_runs",
+    "valid_after", "expires_after", "session_persist", "interactive",
+    "trace_tool_calls", "external_triggers", "semantic_hooks",
+    "tags", "producers", "consumers", "inputs", "version",
+}
+
+_EFFORT_VALUES: "set[str]" = {"low", "medium", "high"}
+
+
+def _suggest_field(unknown: str) -> "str | None":
+    """Return the closest known frontmatter field within edit distance 2, or None."""
+    best: "str | None" = None
+    best_dist = 3
+    for k in _KNOWN_FM_FIELDS:
+        if abs(len(k) - len(unknown)) > 2:
+            continue
+        min_len = min(len(k), len(unknown))
+        dist = (
+            sum(a != b for a, b in zip(k[:min_len], unknown[:min_len]))
+            + abs(len(k) - len(unknown))
+        )
+        if dist < best_dist:
+            best_dist, best = dist, k
+    return best
+
+
+def _parse_fm_block(fm_text: str) -> dict:
+    """Parse scheduler-compatible YAML frontmatter subset into a dict."""
+    data: dict = {}
+    cur_list: "str | None" = None
+    for raw in fm_text.splitlines():
+        s = raw.strip()
+        if not s or s.startswith("#"):
+            continue
+        if s.startswith("- ") and cur_list is not None:
+            item = s[2:].strip()
+            if isinstance(data.get(cur_list), list):
+                if item.startswith("{") and item.endswith("}"):
+                    obj: dict = {}
+                    for part in item[1:-1].split(","):
+                        part = part.strip()
+                        if ":" in part:
+                            k, _, v = part.partition(":")
+                            obj[k.strip()] = v.strip().strip('"').strip("'")
+                    data[cur_list].append(obj)
+                else:
+                    data[cur_list].append(item.strip('"').strip("'"))
+            continue
+        if ":" in s:
+            key, _, val = s.partition(":")
+            key = key.strip()
+            val = val.strip()
+            if val == "":
+                data[key] = []
+                cur_list = key
+            else:
+                v: object = val.strip('"').strip("'")
+                try:
+                    v = int(v)  # type: ignore[assignment]
+                except (ValueError, TypeError):
+                    try:
+                        v = float(v)  # type: ignore[assignment]
+                    except (ValueError, TypeError):
+                        lv = str(v).lower()
+                        if lv == "true":
+                            v = True
+                        elif lv == "false":
+                            v = False
+                data[key] = v
+                cur_list = None
+    return data
+
+
+def _validate_job_file(
+    path: Path, manifest_names: "set[str]"
+) -> "list[tuple[str, str]]":
+    """Return (level, message) findings. level in {error, warning, ok, info}."""
+    import re as _re
+
+    findings: "list[tuple[str, str]]" = []
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        findings.append(("error", f"cannot read file: {exc}"))
+        return findings
+
+    fm_match = _re.match(r"\A---\s*\n(.*?)\n---\s*\n?", text, _re.DOTALL)
+    if not fm_match:
+        findings.append(("error", "no YAML frontmatter (file must begin with ---)"))
+        return findings
+
+    fm = _parse_fm_block(fm_match.group(1))
+
+    # Unrecognized fields
+    for key in fm:
+        if key not in _KNOWN_FM_FIELDS:
+            sug = _suggest_field(key)
+            hint = f" (did you mean '{sug}'?)" if sug else ""
+            findings.append(("warning", f"unrecognized field '{key}'{hint}"))
+
+    # Cron
+    cron = str(fm.get("cron", "")).strip()
+    if cron:
+        try:
+            _cron_matches(cron, datetime.now())
+        except (ValueError, IndexError) as exc:
+            findings.append(("error", f"invalid cron '{cron}': {exc}"))
+        else:
+            try:
+                nxt = _cron_next(cron, datetime.now(timezone.utc))
+                label = _fmt_next_fire(nxt, datetime.now(timezone.utc)) if nxt else "never fires"
+                findings.append(("ok", f"cron: '{cron}' — next: {label}"))
+            except Exception:
+                findings.append(("ok", f"cron: '{cron}'"))
+    else:
+        if not fm.get("external_triggers"):
+            findings.append(("info", "no cron or external_triggers — fires ad-hoc only"))
+
+    # Budget
+    raw_budget = fm.get("max_budget_usd")
+    if raw_budget is not None:
+        try:
+            b = float(raw_budget)
+            if b <= 0:
+                findings.append(("error", f"max_budget_usd must be > 0 (got {b})"))
+            elif b > 10:
+                findings.append(("warning", f"max_budget_usd ${b:.2f} is unusually high (> $10)"))
+            else:
+                findings.append(("ok", f"budget: ${b:.2f}/run"))
+        except (ValueError, TypeError):
+            findings.append(("error", f"max_budget_usd must be a number (got {raw_budget!r})"))
+
+    # Turns
+    raw_turns = fm.get("max_turns")
+    if raw_turns is not None:
+        try:
+            t = int(raw_turns)
+            if t <= 0:
+                findings.append(("error", f"max_turns must be > 0 (got {t})"))
+            elif t > 200:
+                findings.append(("warning", f"max_turns {t} is unusually high (> 200)"))
+        except (ValueError, TypeError):
+            findings.append(("error", f"max_turns must be an integer (got {raw_turns!r})"))
+
+    # Effort
+    effort = str(fm.get("effort", "")).strip()
+    if effort and effort not in _EFFORT_VALUES:
+        findings.append(("warning", f"effort '{effort}' not recognized — expected: low / medium / high"))
+
+    # ISO dates
+    now_dt = datetime.now(timezone.utc)
+    for field in ("valid_after", "expires_after"):
+        val = str(fm.get(field, "")).strip()
+        if val:
+            try:
+                dt = datetime.fromisoformat(val)
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
+                if field == "expires_after" and dt < now_dt:
+                    findings.append(("warning", f"{field}: '{val}' is already in the past — job is auto-disabled"))
+            except ValueError:
+                findings.append(("error", f"{field}: '{val}' is not a valid ISO date"))
+
+    # Producer references
+    producers = fm.get("producers", [])
+    if isinstance(producers, list) and manifest_names:
+        for p in producers:
+            p_name = p.get("name", "") if isinstance(p, dict) else str(p)
+            p_name = str(p_name).strip().strip('"').strip("'")
+            if p_name and p_name not in manifest_names:
+                findings.append(("error", f"producer '{p_name}' is not an installed job"))
+
+    # External trigger paths
+    ext = fm.get("external_triggers", [])
+    if isinstance(ext, list):
+        for trig in ext:
+            if isinstance(trig, dict):
+                ttype = str(trig.get("type", ""))
+                tpath = str(trig.get("path", "")).strip().strip('"').strip("'")
+                if ttype in ("file_added", "file_changed") and tpath:
+                    if not Path(os.path.expanduser(tpath)).exists():
+                        findings.append(
+                            ("warning", f"external_trigger path not found: {tpath}")
+                        )
+
+    return findings
+
+
+def cmd_validate(names: "list[str]", all_jobs: bool = False) -> None:
+    """Validate job frontmatter schema, cron syntax, and producer references."""
+    manifest_names: "set[str]" = set()
+    if MANIFEST.exists():
+        try:
+            m = json.loads(MANIFEST.read_text())
+            manifest_names = {j["name"] for j in m.get("jobs", [])}
+        except (OSError, ValueError):
+            pass
+
+    paths: "list[tuple[str, Path]]" = []
+    if all_jobs:
+        for md in sorted(JOBS_DIR.glob("*.md")):
+            if not md.name.startswith("."):
+                paths.append((md.stem, md))
+        for jd in sorted(JOBS_DIR.iterdir()):
+            if jd.is_dir() and not jd.name.startswith("."):
+                jmd = jd / "JOB.md"
+                if jmd.exists():
+                    paths.append((jd.name, jmd))
+        if not paths:
+            print("  no jobs installed")
+            return
+    else:
+        for name in names:
+            flat = JOBS_DIR / f"{name}.md"
+            module_entry = JOBS_DIR / name / "JOB.md"
+            if flat.exists():
+                paths.append((name, flat))
+            elif module_entry.exists():
+                paths.append((name, module_entry))
+            else:
+                die(f"job not found: {name}")
+
+    n_errors = n_warnings = 0
+    for job_name, path in paths:
+        print(f"  validating {job_name}...")
+        findings = _validate_job_file(path, manifest_names)
+
+        for level, msg in findings:
+            if level == "error":
+                print(f"  \033[31m✗\033[0m {msg}")
+            elif level == "warning":
+                print(f"  \033[33m⚠\033[0m {msg}")
+            elif level == "ok":
+                print(f"  \033[32m✓\033[0m {msg}")
+            else:
+                print(f"    {msg}")
+
+        ne = sum(1 for lv, _ in findings if lv == "error")
+        nw = sum(1 for lv, _ in findings if lv == "warning")
+        n_errors += ne
+        n_warnings += nw
+
+        if ne == 0 and nw == 0:
+            print(f"  \033[32m✓ all checks passed\033[0m")
+        else:
+            parts = []
+            if ne:
+                parts.append(f"{ne} error{'s' if ne != 1 else ''}")
+            if nw:
+                parts.append(f"{nw} warning{'s' if nw != 1 else ''}")
+            print(f"  {', '.join(parts)}")
+
+        if len(paths) > 1:
+            print()
+
+    if len(paths) > 1:
+        if n_errors == 0 and n_warnings == 0:
+            print(f"\033[32m  all {len(paths)} jobs valid\033[0m")
+        else:
+            print(f"  total: {n_errors} error(s), {n_warnings} warning(s) across {len(paths)} jobs")
+
+    if n_errors > 0:
+        sys.exit(1)
 
 
 def cmd_inspect(name: str) -> None:
@@ -2668,6 +2941,13 @@ def main() -> None:
         if not add_path:
             die("usage: clauck add <path> [--name NAME] [--when \"schedule\"]")
         cmd_add(add_path, name=add_name, when=add_when)
+    elif cmd == "validate":
+        if "--all" in rest:
+            cmd_validate([], all_jobs=True)
+        elif rest:
+            cmd_validate([r for r in rest if not r.startswith("-")])
+        else:
+            die("usage: clauck validate <name> [<name2> ...] | --all")
     elif cmd == "inspect" and rest:
         cmd_inspect(rest[0])
     elif cmd == "doctor":


### PR DESCRIPTION
## Closes #61

## Motivation

When a user writes or imports a new job, there is no way to verify the frontmatter is correct before the scheduler's next 60-second tick. A typo in a field name (`croon:` instead of `cron:`), an invalid cron expression, or a producer reference pointing to a non-existent job all fail silently — the job either never fires or behaves unexpectedly and the user has no immediate feedback.

`clauck validate` closes this gap with a fast, pure-Python check that runs in < 200ms and exits non-zero on errors, making it CI-friendly as well.

## Before / After

**Before:** write a job with `croon: "0 9 * * 1-5"` → scheduler silently ignores the field, job is ad-hoc-only, user doesn't know why it never fires automatically.

**After:**
```
$ clauck validate my-job
  validating my-job...
  ⚠ unrecognized field 'croon' (did you mean 'cron'?)
    no cron or external_triggers — fires ad-hoc only
  ✓ budget: $2.00/run
  1 warning
```

Full error example:
```
$ clauck validate bad-job
  validating bad-job...
  ⚠ unrecognized field 'croon' (did you mean 'cron'?)
  ✗ max_turns must be > 0 (got 0)
  ⚠ max_budget_usd $25.00 is unusually high (> $10)
  ⚠ expires_after: '2024-01-01' is already in the past — job is auto-disabled
  1 error, 3 warnings
```
Exit code 1 (error), exit code 0 (warnings only).

## Cost-to-Value Proposition

281 lines across one file, zero new dependencies. No LLM calls — runs in < 200ms. The checks integrate naturally with the existing `_cron_matches` / `_cron_next` / `_fmt_next_fire` helpers already in the codebase.

The `clauck edit` post-save check (a ~10-line text scan) is superseded by this more thorough validation.

## Confidence-to-Impact Proposition

All logic is pure Python with no external dependencies. The cron validation reuses existing tested helpers. The unrecognized-field detection uses a simple edit-distance heuristic (same algorithm as many CLI tools) that correctly catches `croon → cron`, `max_turn → max_turns`, etc.

Exit codes:
- `0`: no errors (warnings and info are non-blocking)
- `1`: one or more errors (invalid cron, broken producer ref, etc.)

## Checks Implemented

| Category | Level | Check |
|---|---|---|
| Frontmatter | error | Missing or unparseable |
| Field names | warning | Unrecognized key + "did you mean?" suggestion |
| Cron | error | Invalid syntax or wrong field count |
| Cron | ok/info | Next-fire preview when valid; ad-hoc note when absent |
| Budget | error/warning | ≤ 0 or > $10 |
| Turns | error/warning | ≤ 0 or > 200 |
| Effort | warning | Not in {low, medium, high} |
| ISO dates | error/warning | Unparseable; `expires_after` already past |
| Producers | error | Name not found in installed manifest |
| Ext triggers | warning | Path doesn't exist on filesystem |

## Validation Steps

```bash
# 1. Syntax check
/usr/bin/python3 -c "import ast; ast.parse(open('lib/clauck').read()); print('ok')"

# 2. Valid job
clauck validate heartbeat
# → ✓ all checks passed

# 3. Typo detection
# Edit a job temporarily: change 'cron' to 'croon'
# Then:
clauck validate heartbeat
# → ⚠ unrecognized field 'croon' (did you mean 'cron'?)

# 4. Bulk validation
clauck validate --all
# → validates all installed jobs with per-job output and aggregate totals

# 5. CI usage (exit code)
clauck validate heartbeat && echo "valid" || echo "invalid"
```

## External Artifacts

- Issue: https://github.com/CoreyRDean/clauck/issues/61