### PR TITLE
[#63] feat: clauck inspect — show runtime state section

### DIFF
--- a/lib/clauck
+++ b/lib/clauck
@@ -1368,6 +1368,59 @@ def cmd_inspect(name: str) -> None:
                 print("\n  Internal stage DAG:")
                 _render_internal_dag("JOB.md", "", False, set())
 
+    # --- Runtime state ---
+    lock_dir = STATE_DIR / f"{name}.lock.d"
+    pid_file = lock_dir / "pid"
+    last_start_file = STATE_DIR / f"{name}.last-start"
+    state = job_state(name)
+
+    running_pid: int | None = None
+    if lock_dir.is_dir() and pid_file.exists():
+        try:
+            p = int(pid_file.read_text().strip())
+            os.kill(p, 0)
+            running_pid = p
+        except (OSError, ValueError, ProcessLookupError):
+            pass  # stale lock — process gone
+
+    last_start_ts: int | None = None
+    if last_start_file.exists():
+        try:
+            last_start_ts = int(last_start_file.read_text().strip())
+        except (OSError, ValueError):
+            pass
+
+    print("  Runtime state:")
+    if running_pid is not None:
+        print(f"  Status:     RUNNING (PID {running_pid})")
+    elif job.get("disabled"):
+        print("  Status:     paused (manually disabled)")
+    elif state.get("auto_disabled"):
+        ad = state["auto_disabled"]
+        if isinstance(ad, dict):
+            reason = ad.get("reason", "auto-disabled")
+            when = ad.get("at", "")
+            suffix = f" (since {when})" if when else ""
+            print(f"  Status:     auto-disabled — {reason}{suffix}")
+        else:
+            print("  Status:     auto-disabled")
+    else:
+        print("  Status:     idle")
+
+    if state.get("last_run"):
+        print(f"  Last run:   {state['last_run']}")
+
+    if last_start_ts is not None:
+        print(f"  Last start: {datetime.fromtimestamp(last_start_ts).isoformat()}")
+
+    if state.get("session_id"):
+        persist_flag = job.get("session_persist", False)
+        label = "persist enabled" if persist_flag else "stale (persist disabled)"
+        print(f"  Session:    {state['session_id']} ({label})")
+
+    if state.get("runs_remaining") is not None:
+        print(f"  Runs left:  {state['runs_remaining']}")
+
     print()
 
 

--- a/lib/scheduler.py
+++ b/lib/scheduler.py
@@ -737,6 +737,7 @@ def write_manifest(jobs: list[dict]) -> None:
                 "trigger_command": f'{JOBS_DIR / "trigger-job.sh"} {j["name"]}',
                 "prompt_path": j["path"],
                 "module_root": j.get("module_root", ""),
+                "session_persist": bool(j.get("session_persist", False)),
             }
             for j in visible_jobs
         ],


### PR DESCRIPTION
Closes #63

## Motivation

`clauck inspect <name>` shows a job's static configuration but nothing about its runtime state. The most common debugging question — "why didn't my job run?" — requires manually reading state files under `~/.clauck/.state/`. This closes that gap by surfacing all relevant runtime state directly in the inspect output.

## Before / After

**Before:** `clauck inspect heartbeat` shows cron, tags, triggers, and DAG. Nothing about whether the job is currently running, when it last ran, or why it might be disabled.

**After:**
```
  Runtime state:
  Status:     idle
  Last run:   2026-04-17T08:00:01
  Last start: 2026-04-17T08:00:01
```

Or, for a currently-running job:
```
  Runtime state:
  Status:     RUNNING (PID 84213)
  Last run:   2026-04-16T08:00:01
  Last start: 2026-04-17T08:00:01
```

Or, for an auto-disabled job (e.g. after PR #56 budget-circuit-breaker):
```
  Runtime state:
  Status:     auto-disabled — budget_exceeded (since 2026-04-17T06:30:12)
  Last run:   2026-04-17T06:30:12
  Last start: 2026-04-17T06:30:01
```

## Cost-to-Value

- **54 lines added** across `lib/clauck` (+53) and `lib/scheduler.py` (+1)
- No new dependencies, no new state files, no frontmatter changes
- The single scheduler.py change adds `session_persist` to the manifest export so `cmd_inspect` can display session status without re-parsing frontmatter

## Confidence-to-Impact

- All 105 existing tests pass unchanged
- `ruff check --select=E9,F` and `ast.parse()` pass on both changed files
- No scheduler behavior changed — manifest gets one additional boolean field
- Running-status check uses `os.kill(pid, 0)` (POSIX, no shell subprocess) to verify PID liveness; stale locks are handled gracefully (show idle, not running)

## Validation Steps

```bash
# 1. Fire a job that has a short debounce and check inspect
clauck fire heartbeat
clauck inspect heartbeat
# Expect: Status: idle, Last run: <timestamp>, Last start: <timestamp>

# 2. While a long-running job is active, inspect it
clauck fire <some-job>  # in background
clauck inspect <some-job>
# Expect: Status: RUNNING (PID <n>)

# 3. Pause a job and check
clauck pause heartbeat
clauck inspect heartbeat
# Expect: Status: paused (manually disabled)
clauck resume heartbeat
```

## Related

- Pairs naturally with #61 (`clauck validate`) — static config + runtime state together give a complete picture of a job's health
- If #53 (budget circuit breaker) lands, the auto-disabled branch will surface the exhaustion reason directly here