### PR TITLE
[#76] docs: roll out INTENT.md to CLAUDE.md, README, CONTRIBUTING, and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,21 @@
 - [ ] Marketplace job (new or updated)
 - [ ] Documentation
 - [ ] Refactoring (no behavior change)
+- [ ] INTENT.md amendment (contract change)
+
+## Intent contract alignment
+
+<!--
+Optional but recommended for architectural changes. Cite which part of
+INTENT.md this change serves:
+
+- Primitive served: accept / compile / execute / observe / persist / orchestrate
+- Non-negotiable preserved (or explicitly amended): §3 #N
+- Architectural property extended: composability / self-observation / intent-as-artifact
+- Decision filter pass: questions 1, 2, 3
+
+Skip this section for simple bug fixes, marketplace jobs, docs, and typo fixes.
+-->
 
 ## Checklist
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,15 +14,19 @@
 
 ## Harness compatibility
 
-**clauck is designed for the Claude Code CLI (`claude` command-line tool).** It invokes `claude -p` for non-interactive job execution.
+There are two independent axes here, often confused. `INTENT.md §6` covers both.
 
-| Harness | Support level |
+**Axis 1 — which harness runs *clauck jobs*.** At v1, Claude CLI (`claude -p`) is the only supported job runner. Alternative runners (Codex, Cursor, Aider via a per-job `harness:` field) are **deferred** — consistent with the contract, not prioritized, revisited when a concrete second-harness need exists. Not a promise; not a rejection.
+
+**Axis 2 — which harness an *agent* is running in when they interact with clauck.** This is unrelated to Axis 1. Any harness that can speak MCP (via `clauck mcp`) or shell out to the CLI can drive clauck. This is supported now and is a stable interface per `INTENT.md §3` non-negotiable #8.
+
+| Harness | Can agents in this harness drive clauck? (Axis 2) |
 |---|---|
-| **Claude Code CLI** | Full support. First-class citizen. All features work. |
-| Claude Desktop (Chat) | Can answer questions about clauck, browse the marketplace, contribute to the repo. Cannot install, schedule, or run jobs. |
-| Claude Desktop (CoWork) | Can potentially install via Bash, modify job files. Cannot create persistent scheduled sessions. |
-| Claude Code (Cloud) | No local filesystem access. Cannot run clauck. |
-| Codex, Cursor, Aider | Planned alternative harness support (per-job `harness:` field). Not yet implemented. |
+| **Claude Code CLI** | Yes. Full support. Primary interaction surface. |
+| Claude Desktop (Chat) | Partial. Can answer questions, browse marketplace, contribute to repo. Cannot fire jobs without Bash-capable context. |
+| Claude Desktop (CoWork) | Partial. Can install via Bash, modify job files. Cannot establish a persistent scheduler on the user's Mac. |
+| Claude Code (Cloud) | No. Lacks local filesystem and launchd access. |
+| Codex, Cursor, Aider, any MCP-capable agent | Yes once `clauck mcp` (#34) is stable. Today, only via CLI shell-out. |
 
 If you're running in a non-CLI harness: be upfront with the user about what you can and can't do. Satisfy their intent as far as the harness allows. Point them to the CLI for full functionality.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,9 +3,11 @@
 > **This file is for agents.** If you're a human, read [README.md](README.md) instead.
 > If you're an agent that landed here from a web search or user request, this is your primary reference.
 
+> **Before making architectural decisions or proposing changes, read [INTENT.md](INTENT.md).** It is the intent contract for clauck — identity, non-negotiables, architectural properties, decision filter, scope boundaries, chosen policies. This file (CLAUDE.md) is the operational playbook; `INTENT.md` is the authority the playbook serves.
+
 ## What is clauck?
 
-clauck is a workflow automation system for macOS that runs `claude -p` sessions on cron schedules, event triggers, and producer/consumer pipelines. It uses launchd (macOS's native service manager) to tick every 60 seconds, evaluating cron expressions and external triggers, resolving DAG pipelines, and dispatching jobs.
+**clauck is a local agent runtime for macOS.** It is the substrate that agent workflows execute on — the way Node.js is a runtime for JavaScript or Docker is a runtime for containers. The runtime accepts intent, compiles it to durable Markdown jobs, executes with full user-level trust, observes execution, persists state across runs, and orchestrates dependencies (cron schedules, event triggers, DAG pipelines). See `INTENT.md §1` for the full six-primitive definition.
 
 **Repo:** https://github.com/CoreyRDean/clauck
 **Install:** `curl -sSL https://raw.githubusercontent.com/CoreyRDean/clauck/main/install.sh | bash`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,18 @@ Thanks for considering contributing. This project is young and benefits from imp
 - [SECURITY.md](SECURITY.md) for reporting vulnerabilities.
 - [Marketplace contribution guide](#adding-a-job-to-the-marketplace) below for submitting pre-made jobs.
 
+## Design discipline
+
+Before proposing a non-trivial change, read [INTENT.md](INTENT.md). It defines what clauck is, what it's not, and the decision filter every new capability should pass:
+
+1. **Does this require a local agent runtime, or could it run in a sandbox?** If it could run in a sandbox, it probably belongs somewhere else.
+2. **Does this serve one of the six runtime primitives?** (Accept intent, compile, execute, observe, persist, orchestrate.)
+3. **Does this preserve the non-negotiables and architectural properties?**
+
+PRs that change runtime behavior in ways inconsistent with the contract must either reshape to fit or amend the contract first (see `INTENT.md §8`). Non-trivial PR descriptions should cite which primitive, non-negotiable, or property the change serves — reviewers check this.
+
+Simple bug fixes, marketplace jobs, docs corrections, and typo fixes do not require a citation. Architectural changes do.
+
 ## Development setup
 
 ```bash

--- a/INTENT.md
+++ b/INTENT.md
@@ -1,0 +1,174 @@
+# INTENT
+
+**Version:** v1
+**Status:** Adopted
+**Scope:** Binds the `CoreyRDean/clauck` upstream repository. Revised only by PR amending this file.
+
+This document is the intent contract for clauck. It is the first thing to consult when proposing a change, reviewing a PR, or deciding whether something belongs in clauck at all. When this contract conflicts with other documentation, this contract wins until it is amended.
+
+---
+
+## 1. Identity
+
+**clauck is a local agent runtime for macOS.**
+
+It is the substrate that agent workflows execute on — the way Node.js is a runtime for JavaScript or Docker is a runtime for containers. Everything else — the scheduler, the CLI, the marketplace, the semantic interpreter, the doctor — is a layer on the runtime.
+
+The runtime does six things:
+
+1. **Accepts intent** — from English, from YAML, from the marketplace, from agents.
+2. **Compiles intent to durable work** — file-backed Markdown jobs as source of truth.
+3. **Executes with full user-level trust** — no sandbox, no permission gate, no cloud.
+4. **Observes execution** — logs, manifest, oplog, dispatch log, state.
+5. **Persists state across executions** — session persistence, durable state files, cross-run memory.
+6. **Orchestrates dependencies** — DAGs, pipelines, consumers, temporal gates, external triggers, events.
+
+Every capability in clauck must serve one of these six primitives. Capabilities that don't either belong in a layer above, or not at all.
+
+---
+
+## 2. Operators
+
+clauck serves two kinds of operator in equal standing.
+
+### The human operator
+
+A technical user who:
+
+- Understands `--dangerously-skip-permissions` and chooses it deliberately
+- Values logs over guardrails
+- Would rather fork than wait for upstream to fix something
+- Already runs multiple agent sessions and wants them to coordinate
+- Measures agent work in cost and outcomes, not turn counts
+
+clauck is **not** designed for users who want a GUI, need cloud execution, want someone else to manage security, or don't know what launchd is. This exclusion is calibration, not gatekeeping — every feature that tries to serve both this user and a sandboxed-agent user under-serves both.
+
+### The agent operator
+
+A first-class operator alongside the human. The canonical first interaction is *"Hey Claude, install clauck."* Agents install, configure, author, fire, inspect, pause, resume, compose, and report through the same surfaces humans use.
+
+Every agent-facing surface — the skill file, the SessionStart hook, the semantic CLI fallthrough, `clauck mcp`, the frontmatter schema, the marketplace package format — is a **protocol**. Versioned, deprecated with lifecycle, never broken silently. Third parties can build agents, libraries, and tools against these interfaces with the same stability guarantees as the human-facing CLI.
+
+Humans drive through agents more often than through files. The contract honors that.
+
+---
+
+## 3. Non-negotiables
+
+These are decided. When they conflict with feature requests, the non-negotiables win. When they conflict with each other, the debate is explicit and visible, not buried.
+
+| # | Non-negotiable | What it means | What it rules out |
+|---|---|---|---|
+| 1 | **Local sovereignty** | Runs as the user, on the user's machine, with the user's permissions. | Cloud execution, remote agents, sandboxed VMs, permission-gated runtimes. |
+| 2 | **Inspectability over restriction** | Every execution is logged. Every state change is visible. Every intent is traceable. | Opaque execution paths, silent failures, untracked mutations. |
+| 3 | **Minimal dependencies** | `/usr/bin/python3` and `/bin/zsh` at runtime. Nothing else. | pip installs, homebrew requirements, compiled binaries, language runtimes. Install-time tools (git, xcode CLT) and dev-time tools (gh, shellcheck) are outside this constraint. |
+| 4 | **Cost as first-class surface** | Every job declares budget. Every run logs cost. Every feature quantifies cost impact. | Hidden costs, unbudgeted agent execution, cost surprises. |
+| 5 | **Backward compatibility** | Jobs written for version N work on version N+1 without edits. | Breaking frontmatter changes, silent semantic shifts, required migrations. |
+| 6 | **Trust via proof** | Every install verifies. Every update is opt-in. Every action is auditable. | Trust-us patterns, magic updates, hidden mutations, telemetry. |
+| 7 | **File-backed source of truth** | Jobs are Markdown files. State is text files. Logs are plaintext. | Databases as authoritative state, binary formats, opaque serialization. |
+| 8 | **Extensibility via stable interfaces** | Frontmatter schema, CLI surface, MCP tool surface, marketplace package format, semantic hooks, and event names are versioned and subject to the deprecation lifecycle. | Silent interface churn, undocumented surfaces that third parties depend on, breaking changes without deprecation windows. |
+| 9 | **Evolvability** | This contract is revised by explicit PR amending this file. | Silent drift. Features that violate the contract without first revising it. |
+
+---
+
+## 4. Architectural properties
+
+Three properties emerge from the primitives. Naming them makes them checkable — a PR can be evaluated against whether it preserves or extends these, not only against whether it serves a primitive.
+
+### Composability
+
+Every primitive composes with every other. DAGs compose jobs. The oplog composes observation across a pipeline. The event bus composes reaction. The marketplace composes packages via dependency resolution. New primitives must compose with existing ones, not replace them. **A feature that requires disabling another primitive to work is a failed design.**
+
+### Self-observation feeds back
+
+`clauck doctor` inspects the runtime. `clauck report` mines user intent into structured issues. Autonomous issue reporting lets jobs, doctor, and utility agents compose draft tickets when they notice problems. The system watches itself and turns findings into durable artifacts — logs, reports, issues, ideas. This is not a nice-to-have; it is a distinguishing property. A runtime that cannot observe and describe its own failures is opaque in a way that violates non-negotiable #2.
+
+### Intent as first-class artifact
+
+Every job carries traceable provenance — a `source:` block tracking where the intent came from (human, agent, marketplace, autogenerated). The oplog preserves the chain: who ran, what they produced, in what order. Drift between expressed intent and executing job is a bug, not a feature. `clauck history` / `clauck trace <invocation-id>` promotes this from convention to primitive.
+
+---
+
+## 5. Decision filter
+
+For every proposed capability, apply these three questions in order:
+
+**1. Does this require a local agent runtime, or could it run in a sandbox?**
+
+If it could run in a sandbox (Cowork, Routines, cloud tasks), it doesn't strengthen clauck's position. Build it only if the integration with the runtime adds value — not because the feature itself is useful.
+
+**2. Does this serve one of the six runtime primitives?**
+
+Accept intent, compile, execute, observe, persist, orchestrate. If the feature doesn't clearly map to one, it probably belongs in a layer above the runtime, or not in clauck at all.
+
+**3. Does this preserve the non-negotiables and architectural properties?**
+
+A feature that requires a new runtime dependency, cloud mediation, a hidden execution path, an unstable interface, or breaks composability is a red flag. Either the feature needs redesign, or the contract needs explicit revision first.
+
+**Scoring:**
+
+- Passes three: build it.
+- Fails one: reshape it.
+- Fails two: defer it.
+- Fails three: reject it.
+
+---
+
+## 6. Scope boundaries
+
+Some capabilities live **in the runtime**. Others live **in layers above** that consume the runtime. Others are **deferred**. Others are explicitly **out of scope**. Mixing these wastes design effort.
+
+| Layer | What belongs here | Examples |
+|---|---|---|
+| **In the runtime** | Anything that serves one of the six primitives and passes the decision filter. | scheduler, dag-runner, external trigger evaluation, oplog, session persistence, `clauck mcp` stdio server, frontmatter schema, cost logging, doctor. |
+| **In layers above** | Anything consuming the runtime's stable interfaces (CLI, MCP, frontmatter, marketplace format) to build higher experiences. Not clauck, but clauck commits to supporting them. | Third-party GUIs, menu-bar apps, web dashboards, mobile notifiers, IDE integrations, analytical tools over the oplog, **agents in any harness driving clauck via MCP**. |
+| **Deferred (eventually, not now)** | Capabilities consistent with the contract but not prioritized. Not promises; not rejections. Revisited when concrete need exists. | Cross-harness execution (per-job `harness:` field for Codex, Cursor, Aider as **job runners**, not as clients). |
+| **Out of scope — explicit non-goals** | Capabilities that violate a non-negotiable or belong to a different product in the ecosystem. | Cloud execution (Routines owns that), sandboxed agents (Cowork owns that), cross-platform support, GUI shipped with the runtime, non-technical user onboarding, telemetry, managed hosting. |
+
+A capability that seems valuable but violates a non-negotiable is a signal that it belongs in a layer above (if consumable via stable interface) or in a different product (if not). It is not a signal to revise the non-negotiables.
+
+**Note on harness portability.** Two independent axes: (a) agents in other harnesses talking to clauck via the MCP interface — that is in layers above, supported now. (b) clauck running jobs on a non-Claude harness — that is deferred. Exposing MCP does not enable (b); (b) requires a separate per-job `harness:` field and multi-harness execution plumbing, and is not a priority at the cost of shipping functionality.
+
+---
+
+## 7. Chosen policies
+
+Where earlier design docs leave decisions open, these are the settled answers. Implemented reality, written down.
+
+| Policy | Setting |
+|---|---|
+| **Concurrency** | Parallel execution with per-provenance locks. Jobs run concurrently; DAG pipelines and same-lineage runs serialize via lock files. Not Serial. Not unbounded parallel. |
+| **Cost** | Declare + log. Every job declares `max_budget_usd` (default 2.00). Harness enforces the ceiling. Cost is logged per run. No mid-run throttling, no multi-threshold escalation policy. |
+| **Platform** | macOS only. Cross-platform is an explicit non-goal. launchd, zsh, `/usr/bin/python3`, BSD utilities may be assumed. A Linux port is a fork, not a port. |
+| **UI** | CLI only, from the runtime. Runtime provides no graphical surface. Third parties may build GUIs on top of the stable CLI + MCP + frontmatter interfaces — those layers are not clauck. |
+| **Execution harness** | Claude CLI (`claude -p`) is the only supported job runner at v1. Alternative harnesses are deferred, not rejected. |
+| **Marketplace role** | First-class distribution channel. Package-manager semantics (install, version, depend, compose, third-party sources) are committed direction. **No commerce** — paid packages, monetization, and revenue sharing are explicit non-goals. |
+| **API stability** | Frontmatter, CLI, MCP tool surface, marketplace package format, skill file, SessionStart hook output follow the deprecation lifecycle: notice → parallel support → migration guide → sunset. Pre-1.0: frontmatter and CLI stability is guaranteed; other surfaces are best-effort. Post-1.0: 2-release or 6-month transition window, whichever is longer. |
+
+---
+
+## 8. How this contract evolves
+
+This contract is a living artifact. It is revised by explicit PR that amends `INTENT.md`.
+
+**Amending process.** A PR that changes runtime behavior in a way inconsistent with this contract must either (a) reshape the change to fit, or (b) first amend the contract, with reviewer sign-off on the amendment before the behavioral change merges. Silent drift is a bug. Drift that earns its place revises the contract first.
+
+**Versioning.** This file carries a version at the top (`v1`, `v2`, …). Each amendment bumps it. Commits and issues cite the version they were written against so intent is unambiguous across time.
+
+**Review discipline.** Every non-trivial PR description should cite which primitives, non-negotiables, or architectural properties it serves — or explicitly declare itself as a contract amendment. Reviewers enforce.
+
+**Scope of authority.** This contract binds the `CoreyRDean/clauck` upstream repository. Forks are free to amend their own copy; the upstream contract applies to upstream decisions only. Third-party extensions (marketplace packages, layer-above tools) are bound only by the stable interfaces they consume, not by the contract itself.
+
+---
+
+## How to use this contract
+
+**Read it when** you are about to make a decision and want to know what has already been decided.
+
+**When evaluating a feature request:** run the decision filter (§5). If it passes, build it. If it fails, reshape or defer it.
+
+**When writing docs or the README:** lead with the identity. Support with features. Never lead with features.
+
+**When a contributor proposes something that doesn't fit:** point at this contract. If they make a case for revising it, that's a real conversation — amend the contract first. If they're simply not aligned with what clauck is, that's a clarification, not a compromise.
+
+**When checking for drift:** compare what has been built against the non-negotiables, the six primitives, and the three architectural properties. Drift is when features accumulate that don't serve them. Drift is fixable if caught early.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@
 <!-- AGENT: If you're an AI agent, read CLAUDE.md first — it's your primary reference.
      https://raw.githubusercontent.com/CoreyRDean/clauck/main/CLAUDE.md -->
 
-Workflow automation powered by AI agents. Schedule tasks, chain pipelines, react to events, and build automations that think — all from plain English.
+**clauck is a local agent runtime for macOS.** Schedule agent work, react to events, chain pipelines, and build automations that think — all from plain English. Runs as you, on your Mac, with your permissions. No cloud. No sandbox. No permission-gated runtime.
+
+The contract that governs this project lives in [INTENT.md](INTENT.md).
 
 > **Hey Claude, install clauck**
 >
@@ -53,6 +55,8 @@ clauck doctor                        # diagnose issues
 Claude Code is powerful. But you have to be there to use it. **clauck** makes your agent work when you're not — on schedules, in response to events, through multi-step pipelines, and with memory that carries across runs.
 
 It's the difference between a tool you use and an agent that works for you.
+
+**The permission model is the wedge.** clauck runs as you, on your machine, with your permissions. Every competitor runs sandboxed. That's the reason clauck exists and the reason you'd pick it over alternatives. Logs over guardrails. Trust earned via inspectability — every execution logged, every state change visible, every intent traceable. If you don't understand `--dangerously-skip-permissions`, clauck is not for you. If you do, it's designed for you.
 
 ### Simple on the surface
 

--- a/docs/superpowers/plans/2026-04-17-intent-contract-rollout.md
+++ b/docs/superpowers/plans/2026-04-17-intent-contract-rollout.md
@@ -1,0 +1,525 @@
+# INTENT Contract Rollout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Integrate the newly-committed `INTENT.md` into the repo so it is discoverable by agents and humans, authoritative in architectural debates, and cited in PRs that affect the contract.
+
+**Architecture:** Purely documentation edits. Five independent, atomic changes across four files. No code, no tests, no migrations. Each change is a self-contained commit so any subset can be reverted independently if reviewer taste diverges.
+
+**Tech Stack:** Markdown. Git. No build, lint, or CI gates touched.
+
+---
+
+## File Structure
+
+Files modified by this plan (no new files created):
+
+| File | Responsibility | Why it changes |
+|---|---|---|
+| `CLAUDE.md` | Agent-facing operating instructions for this repo. Agents read this first. | Must reference `INTENT.md` as authority; must align identity framing with `INTENT.md §1`; must clarify harness-compatibility per `INTENT.md §6`'s two-axes model. |
+| `README.md` | Human-facing entry point. Sets first-impression framing. | Currently leads with "Workflow automation powered by AI agents." Per `INTENT.md §1`, must lead with runtime identity. Must link `INTENT.md`. |
+| `CONTRIBUTING.md` | Contributor expectations. | Needs a short "Design discipline" section pointing PR authors at `INTENT.md` and the decision filter. Light touch, not gatekeeping. |
+| `.github/PULL_REQUEST_TEMPLATE.md` | Default PR body. | Needs one optional prompt asking authors to cite the primitive / non-negotiable / property their change serves, or flag it as a contract amendment. |
+
+`INTENT.md` is already committed at repo root (`1a8d5ef`). This plan does not modify it.
+
+---
+
+## Scope check
+
+Single cohesive rollout: "make `INTENT.md` load-bearing in repo workflow." Five tasks, all doc-only. Does not require decomposition into sub-plans.
+
+---
+
+## Task 1: Reference INTENT.md at the top of CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md:1-12`
+
+- [ ] **Step 1: Read the current CLAUDE.md header**
+
+Run: verify lines 1–12 match the expected pre-state.
+
+Expected pre-state (lines 1–12):
+
+```markdown
+# clauck — Agent Instructions
+
+> **This file is for agents.** If you're a human, read [README.md](README.md) instead.
+> If you're an agent that landed here from a web search or user request, this is your primary reference.
+
+## What is clauck?
+
+clauck is a workflow automation system for macOS that runs `claude -p` sessions on cron schedules, event triggers, and producer/consumer pipelines. It uses launchd (macOS's native service manager) to tick every 60 seconds, evaluating cron expressions and external triggers, resolving DAG pipelines, and dispatching jobs.
+
+**Repo:** https://github.com/CoreyRDean/clauck
+**Install:** `curl -sSL https://raw.githubusercontent.com/CoreyRDean/clauck/main/install.sh | bash`
+```
+
+- [ ] **Step 2: Apply the edit**
+
+Use the Edit tool with this exact `old_string`:
+
+```markdown
+# clauck — Agent Instructions
+
+> **This file is for agents.** If you're a human, read [README.md](README.md) instead.
+> If you're an agent that landed here from a web search or user request, this is your primary reference.
+
+## What is clauck?
+
+clauck is a workflow automation system for macOS that runs `claude -p` sessions on cron schedules, event triggers, and producer/consumer pipelines. It uses launchd (macOS's native service manager) to tick every 60 seconds, evaluating cron expressions and external triggers, resolving DAG pipelines, and dispatching jobs.
+
+**Repo:** https://github.com/CoreyRDean/clauck
+**Install:** `curl -sSL https://raw.githubusercontent.com/CoreyRDean/clauck/main/install.sh | bash`
+```
+
+And this exact `new_string`:
+
+```markdown
+# clauck — Agent Instructions
+
+> **This file is for agents.** If you're a human, read [README.md](README.md) instead.
+> If you're an agent that landed here from a web search or user request, this is your primary reference.
+
+> **Before making architectural decisions or proposing changes, read [INTENT.md](INTENT.md).** It is the intent contract for clauck — identity, non-negotiables, architectural properties, decision filter, scope boundaries, chosen policies. This file (CLAUDE.md) is the operational playbook; `INTENT.md` is the authority the playbook serves.
+
+## What is clauck?
+
+**clauck is a local agent runtime for macOS.** It is the substrate that agent workflows execute on — the way Node.js is a runtime for JavaScript or Docker is a runtime for containers. The runtime accepts intent, compiles it to durable Markdown jobs, executes with full user-level trust, observes execution, persists state across runs, and orchestrates dependencies (cron schedules, event triggers, DAG pipelines). See `INTENT.md §1` for the full six-primitive definition.
+
+**Repo:** https://github.com/CoreyRDean/clauck
+**Install:** `curl -sSL https://raw.githubusercontent.com/CoreyRDean/clauck/main/install.sh | bash`
+```
+
+- [ ] **Step 3: Verify the edit**
+
+Run: `head -20 CLAUDE.md`
+Expected: the new header with the INTENT.md callout and runtime framing appears.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "$(cat <<'EOF'
+docs: CLAUDE.md — reference INTENT.md as authority, align identity framing
+
+Agents read CLAUDE.md first; it must point them at INTENT.md before
+architectural decisions. Also replaces the "workflow automation system"
+framing with the "local agent runtime" identity per INTENT.md §1.
+
+Cites: INTENT v1 §1 (Identity), §9 (Evolvability — contract-first authority).
+EOF
+)"
+```
+
+---
+
+## Task 2: Update CLAUDE.md harness compatibility per INTENT.md §6
+
+The current harness-compatibility table lumps "Codex, Cursor, Aider" under "Planned alternative harness support (per-job `harness:` field)." `INTENT.md §6` clarifies two independent axes: (a) agents-in-other-harnesses talking to clauck via MCP is supported now (via `clauck mcp`), (b) clauck running jobs on a non-Claude harness is deferred. The table should reflect this.
+
+**Files:**
+- Modify: `CLAUDE.md:13-25`
+
+- [ ] **Step 1: Read the current harness section**
+
+Run: verify lines 13–25 match the expected pre-state.
+
+Expected pre-state (lines 13–25):
+
+```markdown
+## Harness compatibility
+
+**clauck is designed for the Claude Code CLI (`claude` command-line tool).** It invokes `claude -p` for non-interactive job execution.
+
+| Harness | Support level |
+|---|---|
+| **Claude Code CLI** | Full support. First-class citizen. All features work. |
+| Claude Desktop (Chat) | Can answer questions about clauck, browse the marketplace, contribute to the repo. Cannot install, schedule, or run jobs. |
+| Claude Desktop (CoWork) | Can potentially install via Bash, modify job files. Cannot create persistent scheduled sessions. |
+| Claude Code (Cloud) | No local filesystem access. Cannot run clauck. |
+| Codex, Cursor, Aider | Planned alternative harness support (per-job `harness:` field). Not yet implemented. |
+
+If you're running in a non-CLI harness: be upfront with the user about what you can and can't do. Satisfy their intent as far as the harness allows. Point them to the CLI for full functionality.
+```
+
+- [ ] **Step 2: Apply the edit**
+
+Use the Edit tool with this exact `old_string`:
+
+```markdown
+## Harness compatibility
+
+**clauck is designed for the Claude Code CLI (`claude` command-line tool).** It invokes `claude -p` for non-interactive job execution.
+
+| Harness | Support level |
+|---|---|
+| **Claude Code CLI** | Full support. First-class citizen. All features work. |
+| Claude Desktop (Chat) | Can answer questions about clauck, browse the marketplace, contribute to the repo. Cannot install, schedule, or run jobs. |
+| Claude Desktop (CoWork) | Can potentially install via Bash, modify job files. Cannot create persistent scheduled sessions. |
+| Claude Code (Cloud) | No local filesystem access. Cannot run clauck. |
+| Codex, Cursor, Aider | Planned alternative harness support (per-job `harness:` field). Not yet implemented. |
+
+If you're running in a non-CLI harness: be upfront with the user about what you can and can't do. Satisfy their intent as far as the harness allows. Point them to the CLI for full functionality.
+```
+
+And this exact `new_string`:
+
+```markdown
+## Harness compatibility
+
+There are two independent axes here, often confused. `INTENT.md §6` covers both.
+
+**Axis 1 — which harness runs *clauck jobs*.** At v1, Claude CLI (`claude -p`) is the only supported job runner. Alternative runners (Codex, Cursor, Aider via a per-job `harness:` field) are **deferred** — consistent with the contract, not prioritized, revisited when a concrete second-harness need exists. Not a promise; not a rejection.
+
+**Axis 2 — which harness an *agent* is running in when they interact with clauck.** This is unrelated to Axis 1. Any harness that can speak MCP (via `clauck mcp`) or shell out to the CLI can drive clauck. This is supported now and is a stable interface per `INTENT.md §3` non-negotiable #8.
+
+| Harness | Can agents in this harness drive clauck? (Axis 2) |
+|---|---|
+| **Claude Code CLI** | Yes. Full support. Primary interaction surface. |
+| Claude Desktop (Chat) | Partial. Can answer questions, browse marketplace, contribute to repo. Cannot fire jobs without Bash-capable context. |
+| Claude Desktop (CoWork) | Partial. Can install via Bash, modify job files. Cannot establish a persistent scheduler on the user's Mac. |
+| Claude Code (Cloud) | No. Lacks local filesystem and launchd access. |
+| Codex, Cursor, Aider, any MCP-capable agent | Yes once `clauck mcp` (#34) is stable. Today, only via CLI shell-out. |
+
+If you're running in a non-CLI harness: be upfront with the user about what you can and can't do. Satisfy their intent as far as the harness allows. Point them to the CLI for full functionality.
+```
+
+- [ ] **Step 3: Verify the edit**
+
+Run: `grep -n "Axis 1" CLAUDE.md && grep -n "Axis 2" CLAUDE.md`
+Expected: both lines present; no stray references to the old "Planned alternative harness support" phrasing.
+
+Also run: `grep -n "Planned alternative harness" CLAUDE.md`
+Expected: no output (0 matches).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "$(cat <<'EOF'
+docs: CLAUDE.md — separate two harness-compatibility axes per INTENT v1 §6
+
+Axis 1 (which harness runs clauck jobs) — Claude CLI only at v1,
+alternatives deferred.
+Axis 2 (which harness agents are in when driving clauck) — any
+MCP-capable or shell-capable harness, supported now.
+
+Previous single table conflated the two, making roadmap (#34 clauck mcp)
+look like it enables Codex-as-job-runner. It does not; that is a
+separate, deferred axis.
+
+Cites: INTENT v1 §6 (Scope boundaries — harness portability note).
+EOF
+)"
+```
+
+---
+
+## Task 3: Rewrite README opener + "Why this exists" section
+
+The current README leads with *"Workflow automation powered by AI agents."* Per `INTENT.md §1`, it should lead with runtime identity. Keep the rest of the README (job marketplace, pipelines, external triggers, temporal scheduling, etc.) unchanged — those are correct and work as progressive disclosure.
+
+**Files:**
+- Modify: `README.md:15-57`
+
+- [ ] **Step 1: Read the current opener and "Why this exists" section**
+
+Run: `sed -n '15,57p' README.md`
+
+Expected pre-state (lines 15 through the end of the "Beyond what native scheduling can do" table, approximately line 80 — verify with `grep -n "Beyond what native scheduling can do" README.md` before editing):
+
+```markdown
+Workflow automation powered by AI agents. Schedule tasks, chain pipelines, react to events, and build automations that think — all from plain English.
+
+> **Hey Claude, install clauck**
+```
+
+(followed by the quickstart block, the "What people build with clauck" table, and the "Why this exists" section)
+
+- [ ] **Step 2: Apply the opener edit**
+
+Use the Edit tool with this exact `old_string`:
+
+```markdown
+Workflow automation powered by AI agents. Schedule tasks, chain pipelines, react to events, and build automations that think — all from plain English.
+```
+
+And this exact `new_string`:
+
+```markdown
+**clauck is a local agent runtime for macOS.** Schedule agent work, react to events, chain pipelines, and build automations that think — all from plain English. Runs as you, on your Mac, with your permissions. No cloud. No sandbox. No permission-gated runtime.
+
+The contract that governs this project lives in [INTENT.md](INTENT.md).
+```
+
+- [ ] **Step 3: Apply the "Why this exists" edit**
+
+Use the Edit tool with this exact `old_string`:
+
+```markdown
+## Why this exists
+
+Claude Code is powerful. But you have to be there to use it. **clauck** makes your agent work when you're not — on schedules, in response to events, through multi-step pipelines, and with memory that carries across runs.
+
+It's the difference between a tool you use and an agent that works for you.
+```
+
+And this exact `new_string`:
+
+```markdown
+## Why this exists
+
+Claude Code is powerful. But you have to be there to use it. **clauck** makes your agent work when you're not — on schedules, in response to events, through multi-step pipelines, and with memory that carries across runs.
+
+It's the difference between a tool you use and an agent that works for you.
+
+**The permission model is the wedge.** clauck runs as you, on your machine, with your permissions. Every competitor runs sandboxed. That's the reason clauck exists and the reason you'd pick it over alternatives. Logs over guardrails. Trust earned via inspectability — every execution logged, every state change visible, every intent traceable. If you don't understand `--dangerously-skip-permissions`, clauck is not for you. If you do, it's designed for you.
+```
+
+- [ ] **Step 4: Verify both edits**
+
+Run: `grep -n "local agent runtime for macOS" README.md`
+Expected: one match at the top of the README body (around line 15).
+
+Run: `grep -n "permission model is the wedge" README.md`
+Expected: one match in the "Why this exists" section.
+
+Run: `grep -n "INTENT.md" README.md`
+Expected: at least one match linking to `INTENT.md`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md
+git commit -m "$(cat <<'EOF'
+docs: README — lead with runtime identity and permission model
+
+Replaces the "workflow automation powered by AI agents" opener with
+the runtime-first identity from INTENT.md §1. Adds a "permission model
+is the wedge" paragraph to "Why this exists" — the market positioning
+that distinguishes clauck from Cowork (sandboxed) and Routines (cloud).
+
+Links INTENT.md at the top so new contributors and agents discover
+the contract immediately.
+
+Cites: INTENT v1 §1 (Identity), §2 (Operators — target user), §3 #1 (Local
+sovereignty), §3 #2 (Inspectability over restriction).
+EOF
+)"
+```
+
+---
+
+## Task 4: Add "Design discipline" section to CONTRIBUTING.md
+
+**Files:**
+- Modify: `CONTRIBUTING.md` — insert a new section between "Quick links" and "Development setup"
+
+- [ ] **Step 1: Read CONTRIBUTING.md to locate the insertion point**
+
+Run: `grep -n "^## " CONTRIBUTING.md`
+Expected: the section headers including `## Quick links` and `## Development setup`.
+
+Expected pre-state around the insertion point:
+
+```markdown
+## Quick links
+
+- [Open an issue](https://github.com/CoreyRDean/clauck/issues/new/choose) for bugs, feature requests, or questions.
+- [SECURITY.md](SECURITY.md) for reporting vulnerabilities.
+- [Marketplace contribution guide](#adding-a-job-to-the-marketplace) below for submitting pre-made jobs.
+
+## Development setup
+```
+
+- [ ] **Step 2: Apply the edit**
+
+Use the Edit tool with this exact `old_string`:
+
+```markdown
+## Quick links
+
+- [Open an issue](https://github.com/CoreyRDean/clauck/issues/new/choose) for bugs, feature requests, or questions.
+- [SECURITY.md](SECURITY.md) for reporting vulnerabilities.
+- [Marketplace contribution guide](#adding-a-job-to-the-marketplace) below for submitting pre-made jobs.
+
+## Development setup
+```
+
+And this exact `new_string`:
+
+```markdown
+## Quick links
+
+- [Open an issue](https://github.com/CoreyRDean/clauck/issues/new/choose) for bugs, feature requests, or questions.
+- [SECURITY.md](SECURITY.md) for reporting vulnerabilities.
+- [Marketplace contribution guide](#adding-a-job-to-the-marketplace) below for submitting pre-made jobs.
+
+## Design discipline
+
+Before proposing a non-trivial change, read [INTENT.md](INTENT.md). It defines what clauck is, what it's not, and the decision filter every new capability should pass:
+
+1. **Does this require a local agent runtime, or could it run in a sandbox?** If it could run in a sandbox, it probably belongs somewhere else.
+2. **Does this serve one of the six runtime primitives?** (Accept intent, compile, execute, observe, persist, orchestrate.)
+3. **Does this preserve the non-negotiables and architectural properties?**
+
+PRs that change runtime behavior in ways inconsistent with the contract must either reshape to fit or amend the contract first (see `INTENT.md §8`). Non-trivial PR descriptions should cite which primitive, non-negotiable, or property the change serves — reviewers check this.
+
+Simple bug fixes, marketplace jobs, docs corrections, and typo fixes do not require a citation. Architectural changes do.
+
+## Development setup
+```
+
+- [ ] **Step 3: Verify the edit**
+
+Run: `grep -n "Design discipline" CONTRIBUTING.md`
+Expected: one match at the new section header.
+
+Run: `grep -n "decision filter" CONTRIBUTING.md`
+Expected: one match inside the new section.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CONTRIBUTING.md
+git commit -m "$(cat <<'EOF'
+docs: CONTRIBUTING — add Design discipline section referencing INTENT.md
+
+Points new contributors at the intent contract before architectural
+work. Names the three-question decision filter inline so the barrier
+to reading it is low. Explicitly exempts simple bug fixes, marketplace
+jobs, and docs from requiring citations — only architectural changes
+need them.
+
+Cites: INTENT v1 §5 (Decision filter), §8 (Evolution — review discipline).
+EOF
+)"
+```
+
+---
+
+## Task 5: Add contract citation prompt to PR template
+
+**Files:**
+- Modify: `.github/PULL_REQUEST_TEMPLATE.md`
+
+- [ ] **Step 1: Read the current PR template**
+
+Run: `cat .github/PULL_REQUEST_TEMPLATE.md`
+
+Expected pre-state (full file content):
+
+```markdown
+## What changed and why
+
+<!-- Brief description of the change. Link to an issue if applicable. -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Marketplace job (new or updated)
+- [ ] Documentation
+- [ ] Refactoring (no behavior change)
+
+## Checklist
+
+- [ ] `bash -n install.sh && bash -n uninstall.sh` passes
+- [ ] `python3 -c "import ast; ast.parse(open('lib/scheduler.py').read())"` passes
+- [ ] Tested `install.sh` on a clean-ish environment (or `--dry-run`)
+- [ ] No secrets, personal paths, or API keys committed
+```
+
+- [ ] **Step 2: Apply the edit**
+
+Use the Edit tool with this exact `old_string`:
+
+```markdown
+## What changed and why
+
+<!-- Brief description of the change. Link to an issue if applicable. -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Marketplace job (new or updated)
+- [ ] Documentation
+- [ ] Refactoring (no behavior change)
+```
+
+And this exact `new_string`:
+
+```markdown
+## What changed and why
+
+<!-- Brief description of the change. Link to an issue if applicable. -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Marketplace job (new or updated)
+- [ ] Documentation
+- [ ] Refactoring (no behavior change)
+- [ ] INTENT.md amendment (contract change)
+
+## Intent contract alignment
+
+<!--
+Optional but recommended for architectural changes. Cite which part of
+INTENT.md this change serves:
+
+- Primitive served: accept / compile / execute / observe / persist / orchestrate
+- Non-negotiable preserved (or explicitly amended): §3 #N
+- Architectural property extended: composability / self-observation / intent-as-artifact
+- Decision filter pass: questions 1, 2, 3
+
+Skip this section for simple bug fixes, marketplace jobs, docs, and typo fixes.
+-->
+```
+
+- [ ] **Step 3: Verify the edit**
+
+Run: `grep -n "INTENT.md amendment" .github/PULL_REQUEST_TEMPLATE.md`
+Expected: one match in the "Type of change" block.
+
+Run: `grep -n "Intent contract alignment" .github/PULL_REQUEST_TEMPLATE.md`
+Expected: one match as a new section header.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/PULL_REQUEST_TEMPLATE.md
+git commit -m "$(cat <<'EOF'
+docs: PR template — add optional INTENT contract alignment section
+
+Adds an "INTENT.md amendment" check under "Type of change" so explicit
+contract changes are flagged, and a new optional "Intent contract
+alignment" section prompting citations for architectural PRs.
+
+Explicitly scoped as optional, with guidance to skip for simple bug
+fixes, marketplace jobs, docs, and typo fixes — keeps overhead low.
+
+Cites: INTENT v1 §8 (Evolution — review discipline, amending process).
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+**Spec coverage:** The rollout targets five concrete touchpoints surfaced during brainstorming (CLAUDE.md identity + cross-link, CLAUDE.md harness clarification, README opener + permission-model wedge, CONTRIBUTING.md design discipline, PR template citation prompt). No remaining rollout gaps.
+
+**Placeholder scan:** Each task contains complete `old_string` / `new_string` content, exact grep verifications, and complete commit messages. No TBDs.
+
+**Type consistency:** Not applicable — docs only. Cross-document references all point to `INTENT.md` (one canonical location) with section numbers consistent with the committed `INTENT.md v1`.
+
+**Not in scope:**
+
+- Issue grooming (reviewing open issues against the contract) is a separate, higher-judgment activity — worth doing as a follow-up session but not a doc-edit task.
+- Bumping `INTENT.md` to `v2` for rollout wording tweaks — this plan does not amend the contract.
+- Updating `skill/` or `~/.claude/skills/clauck/SKILL.md` templates — the skill is user-installable and regenerated from `skill/` on install; leave alone unless a contract-level statement belongs there.


### PR DESCRIPTION
## Closes #76

## Motivation

`INTENT.md` was adopted in `1a8d5ef` as the intent contract for clauck. An implementation plan was committed in `8cb9692`. Without referencing `INTENT.md` from the entry points contributors and agents encounter first, it functions as a file that exists but isn't authoritative — invisible in architectural debates and undiscoverable to new contributors.

This PR executes the five-task rollout plan from `docs/superpowers/plans/2026-04-17-intent-contract-rollout.md`.

## Before / After

**Before:** `INTENT.md` exists at repo root but is not linked or cited from `CLAUDE.md`, `README.md`, `CONTRIBUTING.md`, or the PR template. `CLAUDE.md` describes clauck as "a workflow automation system" (not a runtime). The harness-compatibility table conflates two independent axes. The README leads with "Workflow automation powered by AI agents."

**After:** Every primary entry point references `INTENT.md`. Identity framing is consistent with `INTENT.md §1`. The harness table is split into two independent axes. `CONTRIBUTING.md` surfaces the decision filter. The PR template prompts architectural citations.

## Changes (5 atomic commits, each independently revertable)

1. `CLAUDE.md` — add INTENT.md callout + replace "workflow automation" framing with "local agent runtime" identity per `§1`
2. `CLAUDE.md` — split harness-compatibility into Axis 1 (which harness runs jobs) and Axis 2 (which harness agents use to drive clauck) per `§6`
3. `README.md` — lead with runtime identity; add "permission model is the wedge" paragraph to "Why this exists"
4. `CONTRIBUTING.md` — insert "Design discipline" section naming the three-question decision filter; exempts simple bug fixes
5. `.github/PULL_REQUEST_TEMPLATE.md` — add "INTENT.md amendment" type checkbox and optional "Intent contract alignment" section

## Cost-to-Value

Five doc-only edits across four files. No code, no tests, no CI gates. Each commit is independently revertable if reviewer taste diverges on any individual change. Overhead: near-zero. Value: `INTENT.md` becomes a load-bearing artifact in repo workflow rather than a file that exists in isolation.

## Confidence

Documentation-only. All edits are exact matches to the plan's specified `old_string`/`new_string` blocks — no interpretation required. No behavioral changes. Evidence: the five verification greps all passed before committing.

## Validation

```bash
git log --oneline origin/intent-rollout-1776430909 ^main
# 5 commits: each a single-file doc edit matching the plan

grep -n "INTENT.md" CLAUDE.md    # ≥2 matches (header callout + §1 ref + harness §6 ref)
grep -n "INTENT.md" README.md    # ≥1 match (top-of-file link)
grep -n "Design discipline" CONTRIBUTING.md   # 1 match
grep -n "Intent contract alignment" .github/PULL_REQUEST_TEMPLATE.md  # 1 match
```

## Intent contract alignment

- **Primitive served:** accept intent (makes INTENT.md the accepted-intent surface for architectural decisions)
- **Non-negotiable preserved:** §3 #9 (Evolvability — contract-first authority, not silent drift)
- **Architectural property extended:** intent-as-artifact (INTENT.md now functions as a first-class artifact cited in workflow)
- **Decision filter:** passes all three — local runtime work, serves "accept intent" primitive, preserves all non-negotiables