### PR TITLE
[#71] feat: clauck report interactive intent-mining and --inbox

### DIFF
--- a/lib/clauck
+++ b/lib/clauck
@@ -32,7 +32,9 @@ Usage:
                                          (default: --dry --safe — analysis only, no mutations)
     clauck report [<text>]               Draft a GitHub issue from free-text description;
                                          fetches open issues for duplicate detection, prompts
-                                         to submit when run interactively
+                                         to submit when run interactively.
+                                         No args: interactive intent-mining session.
+                                         --inbox: review pending drafts from prior sessions.
     clauck peek                          Live-tail all job logs (Ctrl+C to stop)
     clauck mcp                           Start the MCP stdio server
     clauck mcp --install                 Register MCP server in Claude Desktop and Claude Code
@@ -66,6 +68,7 @@ TRIGGER_SCRIPT = JOBS_DIR / "trigger-job.sh"
 UPDATE_SCRIPT = JOBS_DIR / "update-check.sh"
 UNINSTALL_SCRIPT = JOBS_DIR / "uninstall.sh"
 MARKETPLACE_DIR = HOME / ".claude" / "skills" / "clauck" / "marketplace"
+REPORTS_DIR = JOBS_DIR / "reports"
 
 
 KNOWN_COMMANDS = {
@@ -2564,6 +2567,104 @@ Produce the actionable result directly. No preamble. No explanation of your proc
 If you attempt to use a native scheduling tool, you have failed."""
 
 
+def _find_pending_drafts() -> list:
+    """Return list of draft paths in REPORTS_DIR, newest first."""
+    if not REPORTS_DIR.exists():
+        return []
+    return sorted(
+        REPORTS_DIR.glob("*-draft.json"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+
+
+def _build_interactive_mining_prompt(draft_path: "Path", prefilled: dict | None = None) -> str:
+    """System prompt for an interactive intent-mining session.
+
+    Instructs the agent to mine user intent conversationally, save drafts to
+    disk at draft_path, and submit via gh when the user is satisfied.
+    """
+    prefill_block = ""
+    if prefilled and isinstance(prefilled.get("title"), str):
+        import json as _json
+        prefill_block = f"""
+## Pre-loaded draft (from initial description)
+Use this as a starting point and refine it with the user:
+
+```json
+{_json.dumps(prefilled, indent=2)}
+```
+"""
+
+    return f"""You are the clauck issue reporter in interactive mining mode.
+
+Your goal: collaborate with the user to draft a high-quality GitHub issue.
+{prefill_block}
+## Your process
+
+1. **Introduce yourself briefly** — one sentence. Ask the user to describe their issue or feature request.
+2. **Mine intent** — ask focused follow-up questions. Prefer binary or short-answer questions over open-ended ones. For bugs: Steps to reproduce, expected vs actual. For features: the motivation/why, acceptance criteria.
+3. **Offer exit ramps** — after each exchange, mention "say 'draft it' when you're ready". Don't force extra turns.
+4. **Save the draft** whenever you have a reasonable version. Use:
+```bash
+python3 -c "import json, pathlib; pathlib.Path('{draft_path}').parent.mkdir(parents=True, exist_ok=True); pathlib.Path('{draft_path}').write_text(json.dumps({{'title': 'TITLE', 'body': 'BODY', 'labels': ['enhancement'], 'classification': 'feature', 'related': []}}, indent=2))"
+```
+   Replace TITLE and BODY with the actual values. Update the file on each refinement.
+5. **Show and submit** when the user is satisfied:
+   - Show a one-line summary of the title
+   - Ask: "Submit to GitHub? [y/N]"
+   - On yes: run `gh issue create --title "TITLE" --body "BODY" --label LABEL`
+   - Report the issue URL
+
+## Constraints
+- Only `gh` CLI and `python3 -c` for draft writing are permitted.
+- Do not open PRs. This session is for issue drafting only.
+- If the user says "quit", "exit", or "cancel": save whatever draft exists and exit gracefully.
+- Keep the draft body under 500 words. Focus on clarity, not exhaustiveness.
+"""
+
+
+def _launch_interactive_mining(draft_path: "Path", prefilled: dict | None = None) -> None:
+    """Spawn an interactive Claude session for intent mining."""
+    claude_bin = _find_claude()
+    if not claude_bin:
+        die("claude CLI not found — clauck report requires claude on PATH")
+
+    REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+    empty_mcp = STATE_DIR / ".empty-mcp-config.json"
+    if not empty_mcp.exists():
+        empty_mcp.write_text('{"mcpServers":{}}')
+
+    prompt = _build_interactive_mining_prompt(draft_path, prefilled)
+    allowlist = json.dumps({
+        "permissions": {
+            "defaultMode": "bypassPermissions",
+            "allow": [
+                "Bash(gh *)",
+                "Bash(python3 -c *)",
+            ],
+        }
+    })
+
+    cli = [
+        claude_bin,
+        "--append-system-prompt", prompt,
+        "--setting-sources", "",
+        "--strict-mcp-config",
+        "--mcp-config", str(empty_mcp),
+        "--dangerously-skip-permissions",
+        "--permission-mode", "bypassPermissions",
+        "--settings", allowlist,
+    ]
+
+    try:
+        subprocess.run(cli)
+    except KeyboardInterrupt:
+        pass
+
+
 def _build_report_exec_prompt(tail: str) -> str:
     """System prompt for the report-writing session.
 
@@ -2600,27 +2701,115 @@ def _build_report_exec_prompt(tail: str) -> str:
    - `related`: list of close matches found in step 1. Each entry:
      {{"number": <int>, "title": "<str>", "overlap": "duplicate|related|stale"}}
      Only include issues with genuine overlap. Empty list if none.
+   - `mine`: set to `true` if the description is too vague to draft a quality ticket
+     and interactive refinement would help; `false` otherwise.
 
 4. **Output ONLY valid JSON, no prose, no markdown fences**:
-{{"title": "...", "body": "...", "labels": ["..."], "classification": "bug|feature|idea|question|regression", "related": [{{"number": 0, "title": "...", "overlap": "..."}}]}}
+{{"title": "...", "body": "...", "labels": ["..."], "classification": "bug|feature|idea|question|regression", "related": [{{"number": 0, "title": "...", "overlap": "..."}}], "mine": false}}
 
 Guidelines:
 - If a near-duplicate exists with overlap "duplicate": flag it and still draft the ticket; the user decides whether to proceed.
 - The body field must be the complete markdown body — not a summary of it.
+- Set `mine: true` only when the description genuinely lacks enough detail to produce a useful ticket.
 - Never add fields not in the schema above.
 """
 
 
-def cmd_report(tail: str = "") -> None:
+def _handle_report_inbox() -> None:
+    """Surface pending report drafts and let the user review/submit/discard each."""
+    import shutil as _shutil
+
+    drafts = _find_pending_drafts()
+    if not drafts:
+        print("  no pending drafts")
+        return
+
+    sep = "\u2500" * 60
+    for i, path in enumerate(drafts, 1):
+        try:
+            draft = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            print(f"  {i}. {path.name}  [unreadable — skipping]")
+            continue
+
+        title = draft.get("title", "(untitled)")
+        classification = draft.get("classification", "feature")
+        mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+        print(f"\n  [{i}/{len(drafts)}] {classification}: {title}")
+        print(f"  saved: {mtime}")
+        print(f"  {sep}")
+        body_preview = (draft.get("body") or "")[:300]
+        for line in body_preview.splitlines()[:8]:
+            print(f"  {line}")
+        print()
+
+        if not (sys.stdin.isatty() and sys.stdout.isatty()):
+            continue
+
+        try:
+            resp = input("  [s]ubmit  [d]iscard  [skip/Enter] ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return
+
+        if resp in ("d", "discard"):
+            path.unlink(missing_ok=True)
+            print("  discarded")
+        elif resp in ("s", "submit"):
+            gh_bin = _shutil.which("gh")
+            if not gh_bin:
+                die("gh not found on PATH — install the GitHub CLI to submit issues")
+            labels = draft.get("labels") or ["enhancement"]
+            label = labels[0] if isinstance(labels, list) and labels else "enhancement"
+            body = draft.get("body", "")
+            result = subprocess.run(
+                [gh_bin, "issue", "create", "--title", title, "--body", body, "--label", label],
+                capture_output=True, text=True,
+            )
+            if result.returncode != 0:
+                print(f"  ! submit failed: {result.stderr.strip()}", file=sys.stderr)
+            else:
+                print(f"  \u2713 submitted: {result.stdout.strip()}")
+                path.unlink(missing_ok=True)
+
+
+def cmd_report(tail: str = "", inbox: bool = False) -> None:
     """Draft and optionally submit a GitHub issue from a free-text description.
 
-    Runs a bounded Claude session that fetches open issues for duplicate
-    detection, then drafts a ticket. Prints the draft; on an interactive tty,
-    prompts to submit via `gh issue create`.
+    With no args and an interactive tty, launches an intent-mining session.
+    With --inbox, surfaces pending drafts from prior sessions.
+    With a text argument, runs a headless drafting session.
     """
+    if inbox:
+        _handle_report_inbox()
+        return
+
     import re as _re
     import threading
     import time as _time
+
+    # No args + interactive tty → check for pending drafts or launch mining
+    if not tail and sys.stdin.isatty() and sys.stdout.isatty():
+        pending = _find_pending_drafts()
+        if pending:
+            print(f"  {len(pending)} pending draft(s) — run `clauck report --inbox` to review")
+            print()
+        import datetime as _dt
+        ts = _dt.datetime.now().strftime("%Y%m%dT%H%M%S")
+        draft_path = REPORTS_DIR / f"{ts}-draft.json"
+        print("  Starting interactive intent-mining session...")
+        print("  Describe your issue to Claude. Say 'draft it' when ready to commit.")
+        print()
+        _launch_interactive_mining(draft_path)
+        if draft_path.exists():
+            try:
+                saved = json.loads(draft_path.read_text())
+                title = saved.get("title", "(untitled)")
+                print(f"\n  Draft saved: {title}")
+                print("  Run `clauck report --inbox` to submit or discard it.")
+            except (json.JSONDecodeError, OSError):
+                pass
+        return
 
     claude_bin = _find_claude()
     if not claude_bin:
@@ -2713,6 +2902,24 @@ def cmd_report(tail: str = "") -> None:
             print(claude_result)
         else:
             die("report: no draft produced — check that gh is on PATH and you're authenticated")
+        return
+
+    # Stage 1 flagged description as too vague → offer interactive refinement
+    if draft.get("mine") and sys.stdin.isatty() and sys.stdout.isatty():
+        import datetime as _dt
+        ts = _dt.datetime.now().strftime("%Y%m%dT%H%M%S")
+        draft_path = REPORTS_DIR / f"{ts}-draft.json"
+        print("  \u2192 description needs more context; launching interactive refinement...")
+        print()
+        _launch_interactive_mining(draft_path, prefilled=draft)
+        if draft_path.exists():
+            try:
+                saved = json.loads(draft_path.read_text())
+                saved_title = saved.get("title", "(untitled)")
+                print(f"\n  Draft saved: {saved_title}")
+                print("  Run `clauck report --inbox` to submit or discard it.")
+            except (json.JSONDecodeError, OSError):
+                pass
         return
 
     title = draft.get("title", "").strip()
@@ -3138,8 +3345,9 @@ def main() -> None:
         else:
             cmd_mcp()
     elif cmd == "report":
+        inbox_flag = "--inbox" in rest
         tail = " ".join(r for r in rest if not r.startswith("-"))
-        cmd_report(tail)
+        cmd_report(tail, inbox=inbox_flag)
     elif cmd == "work":
         # `clauck work <text>` is an explicit alias for semantic fallthrough,
         # avoiding conflicts if semantic text starts with a subcommand name.

--- a/tests/test_clauck_report.py
+++ b/tests/test_clauck_report.py
@@ -1,0 +1,151 @@
+"""Unit tests for clauck report interactive mining additions.
+
+Run: python3 -m unittest discover tests
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import json
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+# Import lib/clauck as a module (no .py extension)
+_LIB = Path(__file__).parent.parent / "lib" / "clauck"
+_loader = importlib.machinery.SourceFileLoader("clauck_cli", str(_LIB))
+_mod = _loader.load_module()
+
+_find_pending_drafts = _mod._find_pending_drafts
+_build_interactive_mining_prompt = _mod._build_interactive_mining_prompt
+_build_report_exec_prompt = _mod._build_report_exec_prompt
+
+
+# ---------------------------------------------------------------------------
+# _find_pending_drafts
+# ---------------------------------------------------------------------------
+
+
+class TestFindPendingDrafts(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.reports = Path(self.tmp.name) / "reports"
+        self._orig = _mod.REPORTS_DIR
+        _mod.REPORTS_DIR = self.reports
+
+    def tearDown(self):
+        _mod.REPORTS_DIR = self._orig
+        self.tmp.cleanup()
+
+    def test_no_reports_dir_returns_empty(self):
+        self.assertEqual(_find_pending_drafts(), [])
+
+    def test_empty_dir_returns_empty(self):
+        self.reports.mkdir()
+        self.assertEqual(_find_pending_drafts(), [])
+
+    def test_single_draft_returned(self):
+        self.reports.mkdir()
+        draft = self.reports / "20260101T120000-draft.json"
+        draft.write_text('{"title": "test"}')
+        result = _find_pending_drafts()
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], draft)
+
+    def test_multiple_drafts_newest_first(self):
+        self.reports.mkdir()
+        p1 = self.reports / "20260101T100000-draft.json"
+        p1.write_text('{"title": "older"}')
+        time.sleep(0.02)
+        p2 = self.reports / "20260101T120000-draft.json"
+        p2.write_text('{"title": "newer"}')
+        result = _find_pending_drafts()
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0], p2)
+        self.assertEqual(result[1], p1)
+
+    def test_non_draft_files_ignored(self):
+        self.reports.mkdir()
+        (self.reports / "20260101T100000-draft.json").write_text("{}")
+        (self.reports / "20260101T100000-submitted.json").write_text("{}")
+        (self.reports / "somefile.txt").write_text("ignored")
+        result = _find_pending_drafts()
+        self.assertEqual(len(result), 1)
+
+
+# ---------------------------------------------------------------------------
+# _build_interactive_mining_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestBuildInteractiveMiningPrompt(unittest.TestCase):
+    def test_returns_string(self):
+        p = Path("/tmp/test-draft.json")
+        result = _build_interactive_mining_prompt(p)
+        self.assertIsInstance(result, str)
+
+    def test_draft_path_embedded(self):
+        p = Path("/tmp/my-draft.json")
+        result = _build_interactive_mining_prompt(p)
+        self.assertIn(str(p), result)
+
+    def test_no_prefilled_no_prefill_block(self):
+        p = Path("/tmp/test-draft.json")
+        result = _build_interactive_mining_prompt(p)
+        self.assertNotIn("Pre-loaded draft", result)
+
+    def test_prefilled_included(self):
+        p = Path("/tmp/test-draft.json")
+        prefilled = {"title": "some bug", "body": "body text", "classification": "bug"}
+        result = _build_interactive_mining_prompt(p, prefilled=prefilled)
+        self.assertIn("Pre-loaded draft", result)
+        self.assertIn("some bug", result)
+
+    def test_prefilled_without_title_skipped(self):
+        p = Path("/tmp/test-draft.json")
+        result = _build_interactive_mining_prompt(p, prefilled={"classification": "bug"})
+        self.assertNotIn("Pre-loaded draft", result)
+
+    def test_none_prefilled_skipped(self):
+        p = Path("/tmp/test-draft.json")
+        result = _build_interactive_mining_prompt(p, prefilled=None)
+        self.assertNotIn("Pre-loaded draft", result)
+
+    def test_contains_save_instruction(self):
+        p = Path("/tmp/test-draft.json")
+        result = _build_interactive_mining_prompt(p)
+        self.assertIn("python3 -c", result)
+
+    def test_contains_gh_submit_instruction(self):
+        p = Path("/tmp/test-draft.json")
+        result = _build_interactive_mining_prompt(p)
+        self.assertIn("gh issue create", result)
+
+
+# ---------------------------------------------------------------------------
+# _build_report_exec_prompt — mine field added
+# ---------------------------------------------------------------------------
+
+
+class TestBuildReportExecPromptMineField(unittest.TestCase):
+    def test_mine_field_in_schema(self):
+        prompt = _build_report_exec_prompt("some description")
+        self.assertIn('"mine"', prompt)
+
+    def test_mine_false_default_in_schema(self):
+        prompt = _build_report_exec_prompt("some description")
+        self.assertIn('"mine": false', prompt)
+
+    def test_mine_description_present(self):
+        prompt = _build_report_exec_prompt("some description")
+        self.assertIn("interactive", prompt.lower())
+
+    def test_description_embedded(self):
+        prompt = _build_report_exec_prompt("my custom description")
+        self.assertIn("my custom description", prompt)
+
+    def test_empty_description_fallback(self):
+        prompt = _build_report_exec_prompt("")
+        self.assertIn("(no description provided)", prompt)


### PR DESCRIPTION
## Closes #71

## Motivation

`clauck report` had no path for intent discovery when the user didn't have a well-formed description. Running it with no args spawned a headless session that produced an empty draft — noise, not value. Users with vague ideas had no assisted way to get from fuzzy intent to a submittable ticket. Draft persistence was also absent, so Ctrl-C during a report session lost captured work entirely.

## Before / After

**Before:**
- `clauck report` (no args) → headless session with no user input → empty/low-quality draft
- `mine: true` in Stage 1 had no routing — the flow proceeded to headless submission regardless
- Ctrl-C during a session → all captured context lost
- No way to review or submit drafts from prior sessions

**After:**
- `clauck report` (no args, interactive tty) → launches a Claude intent-mining session that collaborates with the user to produce a quality ticket
- `mine: true` in Stage 1 → interactive refinement path pre-loaded with the interpreter's draft title, body, and classification
- Drafts saved to `~/.clauck/reports/<ts>-draft.json` on every refinement turn — Ctrl-C safe
- `clauck report --inbox` → numbered list of pending drafts with [s]ubmit / [d]iscard / [skip] prompt

## Cost / Value

- **366 lines** across 2 files (`lib/clauck`, `tests/test_clauck_report.py`). No new dependencies.
- 18 new unit tests; 153/153 pass.
- Zero runtime overhead when running in headless/non-tty mode — all new paths gate on `sys.stdin.isatty()`.
- Closes the longest-standing gap in `clauck report` (Phase 2 of #27, deferred from PR #58).

## Confidence

- All new paths gate on `sys.stdin.isatty() and sys.stdout.isatty()` — no behavior change for scheduled/non-interactive invocations.
- `_launch_interactive_mining` uses `--strict-mcp-config` and `--setting-sources ""` — minimal tool surface, same cost discipline as the headless session.
- `_find_pending_drafts` is pure filesystem — no subprocess, no network.
- All CLAUDE.md checks pass: `bash -n install.sh`, `ast.parse(scheduler.py)`, `ast.parse(dag-runner.py)`, `json.load(index.json)`, `ast.parse(lib/clauck)`, `install.sh --dry-run --yes`.

## Validation Steps

```bash
# 1. Run the test suite
cd /path/to/clauck && python3 -m unittest discover tests
# → 153/153 pass

# 2. No-args interactive mining
clauck report
# → "Starting interactive intent-mining session..."
# → Claude launches and mines intent conversationally
# → Draft saved to ~/.clauck/reports/<ts>-draft.json after exit

# 3. Review inbox
clauck report --inbox
# → lists pending drafts with submit/discard prompt (if any exist)

# 4. Verify headless path unchanged (non-tty)
echo "test description" | clauck report "some feature request"
# → same behavior as before this PR (headless drafting, no mining)

# 5. Verify mine=true routing (interactive)
# Run clauck report with a very vague description in an interactive terminal
# → Stage 1 interpreter should set mine: true → mining session launches
```

## Known Limitations

- `_launch_interactive_mining` invokes `claude` without `--max-turns` or `--max-budget-usd` — a runaway interactive session isn't bounded. This matches the existing `clauck report` headless path behavior. Per-session budgeting for interactive mining is a follow-up.
- The interactive mining session only allows `Bash(gh *)` and `Bash(python3 -c *)`. If `gh` is not authenticated, draft-save still works but submission fails with an actionable error message.
- Draft files are `.json` not `.md` per the issue spec — JSON enables structured review in `--inbox` without re-parsing markdown. Functionally equivalent.

## Falsifiability

If `sys.stdin.isatty()` returns `True` in a non-interactive context (e.g., a piped session where the TTY is inherited), the interactive path could activate unexpectedly. Any report of unexpected interactive sessions firing in automation contexts would disprove the safety of the `isatty()` gate.