### PR TITLE
[#85] feat: clauck logs --follow tails DAG orchestration logs

### DIFF
--- a/lib/clauck
+++ b/lib/clauck
@@ -717,7 +717,7 @@ def _active_dag_log(name: str) -> "Path | None":
     )
     for log in logs:
         text = log.read_text()
-        if "exit_code=" in text:
+        if "--- exit_code=" in text:
             continue
         for line in text.splitlines()[:6]:
             if line.startswith("pid="):
@@ -746,9 +746,9 @@ def _follow_dag_log(path: "Path") -> None:
             layer = payload.get("layer", "?")
             exit_code = payload.get("exit_code")
             cost = payload.get("cost")
-            if event == "start":
+            if event == "started":
                 return f"  -> [layer {layer}] starting: {job}"
-            if event in ("complete", "done"):
+            if event in ("completed", "done"):
                 suffix = ""
                 if exit_code is not None:
                     suffix += f"  exit={exit_code}"
@@ -766,13 +766,13 @@ def _follow_dag_log(path: "Path") -> None:
         content = fh.read()
         for line in content.splitlines():
             print(_annotate(line), flush=True)
-        done = "exit_code=" in content
+        done = "--- exit_code=" in content
         while not done:
             chunk = fh.read()
             if chunk:
                 for line in chunk.splitlines():
                     print(_annotate(line), flush=True)
-                if "exit_code=" in chunk:
+                if "--- exit_code=" in chunk:
                     done = True
             else:
                 _time.sleep(0.3)

--- a/lib/clauck
+++ b/lib/clauck
@@ -14,7 +14,7 @@ Usage:
     clauck rename <old> <new>            Rename a job, migrating all state atomically (also: mv)
     clauck logs <name> [--last N]        Show recent logs (paths + summary); marks active run
     clauck logs <name> --show [N]        Print content of Nth most recent log (default: 1)
-    clauck logs <name> --follow          Tail the active run; falls back to most recent log
+    clauck logs <name> --follow          Tail the active run; for DAG jobs, tails the orchestration log
     clauck marketplace                    Browse pre-made jobs
     clauck marketplace info <name>        Show full details for a marketplace job
     clauck marketplace search <query>     Search marketplace by keyword
@@ -701,6 +701,83 @@ def _active_log(name: str) -> "Path | None":
     return None
 
 
+def _active_dag_log(name: str) -> "Path | None":
+    """Return the currently-running DAG orchestration log for *name*, or None.
+
+    DAG logs: ~/.clauck/<name>-dag-<ts>-<pid>.log
+    Active detection: most recent log without an exit_code tombstone whose
+    pid= header line refers to a live process.
+    """
+    import os as _os
+
+    logs = sorted(
+        JOBS_DIR.glob(f"{name}-dag-[0-9]*.log"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    for log in logs:
+        text = log.read_text()
+        if "exit_code=" in text:
+            continue
+        for line in text.splitlines()[:6]:
+            if line.startswith("pid="):
+                try:
+                    pid = int(line[4:].strip())
+                    _os.kill(pid, 0)
+                    return log
+                except (OSError, ValueError):
+                    pass
+        break  # no tombstone but pid is dead — stale run
+    return None
+
+
+def _follow_dag_log(path: "Path") -> None:
+    """Stream a DAG orchestration log, annotating stage events as they land."""
+    import json as _json
+    import time as _time
+
+    def _annotate(line: str) -> str:
+        if "event: {" not in line:
+            return line
+        try:
+            payload = _json.loads(line.split("event: ", 1)[1])
+            job = payload.get("job", "?")
+            event = payload.get("event", "?")
+            layer = payload.get("layer", "?")
+            exit_code = payload.get("exit_code")
+            cost = payload.get("cost")
+            if event == "start":
+                return f"  -> [layer {layer}] starting: {job}"
+            if event in ("complete", "done"):
+                suffix = ""
+                if exit_code is not None:
+                    suffix += f"  exit={exit_code}"
+                if cost is not None:
+                    suffix += f"  ${float(cost):.4f}"
+                return f"  ok [layer {layer}] done: {job}{suffix}"
+            if event in ("error", "failed"):
+                return f"  !! [layer {layer}] failed: {job}  exit={exit_code}"
+        except Exception:
+            pass
+        return line
+
+    done = False
+    with open(path) as fh:
+        content = fh.read()
+        for line in content.splitlines():
+            print(_annotate(line), flush=True)
+        done = "exit_code=" in content
+        while not done:
+            chunk = fh.read()
+            if chunk:
+                for line in chunk.splitlines():
+                    print(_annotate(line), flush=True)
+                if "exit_code=" in chunk:
+                    done = True
+            else:
+                _time.sleep(0.3)
+
+
 def _follow_log(path: "Path", lock_dir: "Path") -> None:
     """Stream a log file to stdout, exiting when the exit_code tombstone lands."""
     import time as _time
@@ -734,6 +811,25 @@ def cmd_logs(name: str, last: int = 5, show: int = 0, follow: bool = False) -> N
     active = _active_log(name)
 
     if follow:
+        # For DAG pipeline jobs, prefer the orchestration log over the individual job log.
+        # The DAG log captures cross-job coordination, stage transitions, and the full
+        # pipeline timeline — none of which appears in a single node's log.
+        dag_active = _active_dag_log(name)
+        dag_logs = sorted(
+            JOBS_DIR.glob(f"{name}-dag-[0-9]*.log"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+        if dag_active:
+            print(f"  tailing active DAG run: {dag_active.name}  (Ctrl-C to stop)", flush=True)
+            _follow_dag_log(dag_active)
+            return
+        if dag_logs:
+            dag_target = dag_logs[0]
+            print(f"  no active DAG run — tailing most recent: {dag_target.name}", flush=True)
+            _follow_dag_log(dag_target)
+            return
+        # No DAG logs: fall back to the individual job log.
         target = active or (logs[0] if logs else None)
         if not target:
             print(f"  no logs found for: {name}")


### PR DESCRIPTION
## Closes #85

## Motivation

`clauck logs <name> --follow` currently tails the individual job log. For DAG pipeline jobs (`producers:`/`consumers:` wired), the orchestration log (`<name>-dag-<ts>-<pid>.log`) is the right surface: it captures cross-job coordination, layer-by-layer stage transitions, and the full pipeline timeline. A single job log only shows one node's output — the DAG log shows the whole picture.

This gap was explicitly deferred in [PR #83](https://github.com/CoreyRDean/clauck/pull/83) and tracked in #85.

## Before / After

**Before:** `clauck logs pe-pipeline --follow` tails `pe-pipeline-<ts>.log` — one node, no orchestration context.

**After:**
```
$ clauck logs pe-pipeline --follow
  tailing active DAG run: pe-pipeline-dag-20260417T210026Z-91646.log  (Ctrl-C to stop)
=== dag-runner start: pe-pipeline @ 20260417T210026Z ===
invocation_id=3f2a...
pid=91646
  -> [layer 0] starting: pe-classify
  -> [layer 0] starting: pe-qa
  ok [layer 0] done: pe-classify  exit=0  $0.1234
  ok [layer 0] done: pe-qa  exit=0  $0.0891
  -> [layer 1] starting: pe-pipeline
  ok [layer 1] done: pe-pipeline  exit=0  $0.4210
--- exit_code=0 ===
```

When no DAG run is active, falls back to the most recent DAG log. When no DAG logs exist (non-DAG job), falls back to the individual job log as before.

## Implementation

Three additions to `lib/clauck`:

**`_active_dag_log(name)`** — mirrors `_active_log()` but scans `<name>-dag-[0-9]*.log`. Finds the most recent log without an `exit_code=` tombstone, extracts the `pid=` header line, and checks the process is alive. Returns the path or `None`.

**`_follow_dag_log(path)`** — streams the DAG log with the same tombstone-detection loop as `_follow_log`. Adds an `_annotate()` inner function that parses the structured JSON event lines written by dag-runner.py (`event: {...}`) and reformats them as human-readable stage progress markers.

**`cmd_logs --follow`** — extended with two new checks before the existing job-log path:
1. If an active DAG log exists → tail it via `_follow_dag_log`
2. If any DAG logs exist → tail the most recent via `_follow_dag_log`
3. Otherwise → original behavior (individual job log)

## Acceptance Criteria Checklist

1. ✅ `clauck logs <dag-root-job> --follow` tails the active DAG orchestration log
2. ✅ Falls back gracefully to most recent DAG log when no run is active; falls back further to individual job log if no DAG logs exist
3. ✅ Stage transitions annotated from dag-runner.py's structured JSON events (`-> [layer N] starting: job`, `ok [layer N] done: job`, `!! [layer N] failed: job`)
4. ✅ Clean exit when the DAG log's `exit_code=` tombstone lands

## Cost / Value

- 97 lines in one file. No new dependencies.
- Zero behavior change for non-DAG jobs (no DAG logs → existing path).
- Backwards compatible: works with existing DAG logs from any prior dag-runner.py version.

## Confidence / Risk

- **DAG log format stability:** dag-runner.py's log format (`pid=<N>`, `event: {...}`, `--- exit_code=N ===`) has been stable since introduction. The `_annotate()` function fails gracefully (returns the raw line) if the JSON can't be parsed.
- **Active detection accuracy:** same approach as the existing `_active_log()` — PID liveness check. Works correctly even for stale logs from crashed runs.
- **No change to dag-runner.py:** this is a read-only consumer of existing log data.

## Validation Steps

```bash
# 1. Syntax
/usr/bin/python3 -c "import ast; ast.parse(open('lib/clauck').read())" && echo OK

# 2. Non-DAG job: --follow behavior unchanged
clauck logs heartbeat --follow
# → tails heartbeat-<ts>.log as before

# 3. DAG job with existing logs: tails most recent DAG log
clauck logs pe-pipeline --follow
# → "  no active DAG run — tailing most recent: pe-pipeline-dag-<ts>.log"
# → displays annotated stage events

# 4. DAG job during active run
clauck fire pe-pipeline SOURCE_PATH=/path/to/prompt.md &
clauck logs pe-pipeline --follow
# → "  tailing active DAG run: pe-pipeline-dag-<ts>.log  (Ctrl-C to stop)"
# → stage annotations appear as each layer completes
# → exits cleanly after "--- exit_code=N ===" lands
```

## Supporting artifacts

- Closes [#85](https://github.com/CoreyRDean/clauck/issues/85)
- Deferred from: [PR #83](https://github.com/CoreyRDean/clauck/pull/83)