### PR TITLE
[#72] feat: clauck report follow-up issue watcher (Phase 2 of #27)

### DIFF
--- a/lib/clauck
+++ b/lib/clauck
@@ -2635,6 +2635,102 @@ Produce the actionable result directly. No preamble. No explanation of your proc
 If you attempt to use a native scheduling tool, you have failed."""
 
 
+_WATCHER_PROMPT_BODY = """\
+You are a GitHub issue state watcher. Your job is to detect meaningful state changes on one GitHub issue and surface them to the user.
+
+## Issue to watch
+
+URL: {{env:CLAUCK_INPUT_ISSUE_URL}}
+
+## What to check
+
+1. Run `gh issue view <URL> --json state,title,labels,comments,closedAt` to get current state.
+2. Read the last known state from `~/.clauck/.state/<job-name>.json` if it exists (ignore file-not-found).
+3. Compare current vs last state. Interesting changes:
+   - Issue **closed** or **reopened**
+   - A label was **added or removed** (especially milestone/target/priority labels)
+   - A **PR was opened** that references this issue — check via `gh pr list --search "closes #<number>" --repo <owner>/<repo> --json number,title,url,state`
+   - Issue was added to a **milestone** or **project**
+4. If any interesting change is detected, report it. If no change, exit silently without posting.
+
+## How to report
+
+Interesting change detected:
+
+- If `CLAUCK_INPUT_NOTIFY_CHANNEL` is non-empty: post a brief Slack message to that channel ID via the Slack MCP `slack_send_message` tool.
+- Otherwise: append to `~/Documents/clauck/<job-name>-updates.md` (create file/dir if needed).
+
+Format:
+
+```
+📌 *<issue title>*
+<change summary — one line each>
+<issue URL>
+```
+
+## State persistence
+
+After each check, write current state to `~/.clauck/.state/<job-name>.json`:
+
+```json
+{
+  "state": "open|closed",
+  "labels": ["label1"],
+  "linked_prs": [123],
+  "checked_at": "ISO-8601 timestamp"
+}
+```
+
+`<job-name>` is the `name:` field from this job's frontmatter.
+
+## Rules
+
+- Do not post if nothing changed since last check.
+- Do not post the issue body — only state changes.
+- If `gh` is not on PATH, write a one-line error to the updates file and exit.
+- If the issue URL is the default placeholder (`/issues/0`), write a setup reminder to the updates file and exit.
+"""
+
+
+def _install_issue_watcher(issue_url: str, notify_channel: str = "") -> str:
+    """Install a watcher job for a GitHub issue. Returns the job name."""
+    import re as _re
+
+    m = _re.search(r"github\.com/([^/]+/[^/]+)/issues/(\d+)", issue_url)
+    if not m:
+        raise ValueError(f"Cannot parse issue URL: {issue_url}")
+    repo = m.group(1)
+    number = m.group(2)
+
+    job_name = f"gh-watch-{number}"
+    job_path = JOBS_DIR / f"{job_name}.md"
+
+    notify_default = notify_channel or ""
+    frontmatter = f"""\
+---
+name: {job_name}
+description: "Watch github.com/{repo}/issues/{number} for state changes"
+cron: "0 12 * * *"
+max_turns: 12
+max_budget_usd: 0.15
+effort: low
+model: haiku
+strict_mcp_config: false
+tags:
+  - github
+  - monitoring
+  - issue-watcher
+inputs:
+  - name: ISSUE_URL
+    default: "{issue_url}"
+  - name: NOTIFY_CHANNEL
+    default: "{notify_default}"
+---
+"""
+    job_path.write_text(frontmatter + "\n" + _WATCHER_PROMPT_BODY)
+    return job_name
+
+
 def _find_pending_drafts() -> list:
     """Return list of draft paths in REPORTS_DIR, newest first."""
     if not REPORTS_DIR.exists():
@@ -3044,7 +3140,38 @@ def cmd_report(tail: str = "", inbox: bool = False) -> None:
     if create_result.returncode != 0:
         print(f"  ! gh issue create failed: {create_result.stderr.strip()}", file=sys.stderr)
         sys.exit(1)
-    print(f"  \u2713 submitted: {create_result.stdout.strip()}")
+    issue_url = create_result.stdout.strip()
+    print(f"  \u2713 submitted: {issue_url}")
+
+    _offer_issue_watcher(issue_url)
+
+
+def _offer_issue_watcher(issue_url: str) -> None:
+    """Prompt the user to install a daily watcher job for the submitted issue."""
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        return
+    if not issue_url.startswith("https://github.com/"):
+        return
+
+    print()
+    try:
+        resp = input(
+            "  Watch this issue? I'll post updates when it closes, gets a PR, or changes labels. [Y/n] "
+        ).strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return
+
+    if resp in ("n", "no"):
+        return
+
+    try:
+        job_name = _install_issue_watcher(issue_url)
+        print(f"  \u2713 watcher installed: {job_name} (daily at noon UTC)")
+        print(f"    Updates → ~/Documents/clauck/{job_name}-updates.md")
+        print(f"    Pause anytime: clauck pause {job_name}")
+    except Exception as exc:
+        print(f"  ! could not install watcher: {exc}", file=sys.stderr)
 
 
 def cmd_semantic(text: str) -> None:

--- a/marketplace/github-issue-watcher.md
+++ b/marketplace/github-issue-watcher.md
@@ -1,0 +1,88 @@
+---
+name: gh-watch-0
+description: "Watch GitHub issue for state changes: closed, PR opened, label changes. Posts updates to Slack self-DM or a local file."
+cron: "0 12 * * *"
+max_turns: 12
+max_budget_usd: 0.15
+effort: low
+model: haiku
+strict_mcp_config: false
+tags:
+  - github
+  - monitoring
+  - issue-watcher
+inputs:
+  - name: ISSUE_URL
+    default: "https://github.com/owner/repo/issues/0"
+  - name: NOTIFY_CHANNEL
+    default: ""
+---
+<!-- CUSTOMIZE BEFORE INSTALLING:
+  1. Set the `name:` field to something unique, e.g. gh-watch-123
+  2. Update the `description:` with the issue title for discoverability
+  3. Set ISSUE_URL default to the exact GitHub issue URL
+  4. Set NOTIFY_CHANNEL to your Slack DM channel ID, or leave blank for local file output
+-->
+
+You are a GitHub issue state watcher. Your job is to detect meaningful state changes on one GitHub issue and surface them to the user.
+
+## Issue to watch
+
+URL: {{env:CLAUCK_INPUT_ISSUE_URL}}
+
+## What to check
+
+1. Run `gh issue view <URL> --json state,title,labels,comments,closedAt` to get current state.
+2. Read the last known state from `~/.clauck/.state/<job-name>.json` if it exists (ignore file-not-found).
+3. Compare current vs last state. Interesting changes:
+   - Issue **closed** or **reopened**
+   - A label was **added or removed** (especially milestone/target/priority labels)
+   - A **PR was opened** that references this issue — check via `gh pr list --search "closes #<number>" --repo <owner>/<repo> --json number,title,url,state`
+   - Issue was added to a **milestone** or **project**
+4. If any interesting change is detected, report it. If no change, exit silently without posting.
+
+## How to report
+
+Interesting change detected:
+
+- If `CLAUCK_INPUT_NOTIFY_CHANNEL` is non-empty: post a brief Slack message to that channel ID via the Slack MCP `slack_send_message` tool. Format:
+
+  ```
+  📌 *<issue title>*
+  <change summary — one line each>
+  <issue URL>
+  ```
+
+- Otherwise: append to `~/Documents/clauck/<job-name>-updates.md`:
+
+  ```markdown
+  ## <YYYY-MM-DD HH:MM UTC>
+
+  <change summary>
+
+  <issue URL>
+  ```
+
+  Create the file if it doesn't exist. Create the directory if it doesn't exist.
+
+## State persistence
+
+After checking (whether or not a change was found), write the current state back to `~/.clauck/.state/<job-name>.json`:
+
+```json
+{
+  "state": "open|closed",
+  "labels": ["label1", "label2"],
+  "linked_prs": [123, 456],
+  "checked_at": "ISO-8601 timestamp"
+}
+```
+
+`<job-name>` is the `name:` field from this job's frontmatter.
+
+## Rules
+
+- Do not post if nothing changed since last check.
+- Do not post the issue body — only state changes.
+- If `gh` is not on PATH, write a one-line error to the updates file and exit.
+- If the issue URL is the default placeholder (`/issues/0`), write a setup reminder to the updates file and exit.

--- a/marketplace/index.json
+++ b/marketplace/index.json
@@ -184,6 +184,26 @@
           "Add your own {{cmd:}} markers to inject other live shell context."
         ]
       }
+    },
+    {
+      "name": "github-issue-watcher",
+      "version": "1.0.0",
+      "path": "github-issue-watcher.md",
+      "category": "monitoring",
+      "tags": ["monitoring", "github", "issue-watcher", "daily", "notifications"],
+      "one_line": "Daily watcher for a single GitHub issue: alerts on close, PR linkage, or label changes. Installed automatically by `clauck report`.",
+      "schedule": "daily at 12:00 UTC (configurable)",
+      "cost_per_run_usd_approx": 0.04,
+      "runs_per_month_approx": 30,
+      "monthly_cost_usd_approx": 1.20,
+      "requires": {
+        "mcps": "none required (Slack optional for push notifications)",
+        "setup": [
+          "Set name: to something unique, e.g. gh-watch-123",
+          "Set ISSUE_URL default to the GitHub issue URL to watch.",
+          "Optionally set NOTIFY_CHANNEL to a Slack DM channel ID for push notifications."
+        ]
+      }
     }
   ]
 }

--- a/tests/test_clauck_report.py
+++ b/tests/test_clauck_report.py
@@ -21,6 +21,7 @@ _mod = _loader.load_module()
 _find_pending_drafts = _mod._find_pending_drafts
 _build_interactive_mining_prompt = _mod._build_interactive_mining_prompt
 _build_report_exec_prompt = _mod._build_report_exec_prompt
+_install_issue_watcher = _mod._install_issue_watcher
 
 
 # ---------------------------------------------------------------------------
@@ -149,3 +150,53 @@ class TestBuildReportExecPromptMineField(unittest.TestCase):
     def test_empty_description_fallback(self):
         prompt = _build_report_exec_prompt("")
         self.assertIn("(no description provided)", prompt)
+
+
+# ---------------------------------------------------------------------------
+# _install_issue_watcher
+# ---------------------------------------------------------------------------
+
+
+class TestInstallIssueWatcher(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self._orig_jobs = _mod.JOBS_DIR
+        _mod.JOBS_DIR = Path(self.tmp.name)
+
+    def tearDown(self):
+        _mod.JOBS_DIR = self._orig_jobs
+        self.tmp.cleanup()
+
+    def test_creates_job_file(self):
+        url = "https://github.com/owner/repo/issues/42"
+        name = _install_issue_watcher(url)
+        job = Path(self.tmp.name) / f"{name}.md"
+        self.assertTrue(job.exists(), f"{job} was not created")
+
+    def test_job_name_contains_issue_number(self):
+        url = "https://github.com/owner/repo/issues/99"
+        name = _install_issue_watcher(url)
+        self.assertIn("99", name)
+
+    def test_job_file_contains_issue_url(self):
+        url = "https://github.com/acme/widget/issues/7"
+        _install_issue_watcher(url)
+        job = Path(self.tmp.name) / "gh-watch-7.md"
+        content = job.read_text()
+        self.assertIn(url, content)
+
+    def test_job_file_has_valid_cron(self):
+        url = "https://github.com/acme/widget/issues/7"
+        _install_issue_watcher(url)
+        job = Path(self.tmp.name) / "gh-watch-7.md"
+        self.assertIn("cron:", job.read_text())
+
+    def test_notify_channel_baked_in(self):
+        url = "https://github.com/acme/widget/issues/5"
+        _install_issue_watcher(url, notify_channel="C123ABC")
+        job = Path(self.tmp.name) / "gh-watch-5.md"
+        self.assertIn("C123ABC", job.read_text())
+
+    def test_invalid_url_raises(self):
+        with self.assertRaises(ValueError):
+            _install_issue_watcher("https://gitlab.com/owner/repo/issues/1")


### PR DESCRIPTION
## Closes #72

## Motivation

`clauck report` lets you submit a GitHub issue from a free-text description, but the loop closes there — you have no visibility into what happens to the issue after submission. Issue #72 asks for a follow-up that keeps the user informed without requiring them to manually poll GitHub.

## Before / After

**Before:** `clauck report` submits an issue and exits. User has no mechanism to know when it's closed, targeted, or gets a PR opened.

**After:** After a successful `gh issue create`, the user is offered a one-question prompt: _"Watch this issue? I'll post updates when it closes, gets a PR, or changes labels. [Y/n]"_ On yes, a customized daily watcher job is installed at `~/.clauck/gh-watch-<number>.md` and begins running automatically.

## Cost / Value

- ~80 lines of new Python + a 60-line marketplace template
- No new dependencies (uses existing `gh` CLI + scheduler infrastructure)
- Watcher job costs ~$0.04/run × 30 days = ~$1.20/month per watched issue (Haiku, 12 turns max)
- Passes all 24 tests (6 new, 18 existing)

## Confidence / Impact

- `_install_issue_watcher` is a pure file-write function with no side effects — easy to test and reason about
- `_offer_issue_watcher` guards with `isatty()` checks, so it's silent in non-interactive contexts
- Backwards compatible: no existing behavior changes; the offer is additive

## Validation Steps

```bash
# Syntax + JSON checks
cd path/to/clauck
/usr/bin/python3 -c "import ast; ast.parse(open('lib/clauck').read()); print('OK')"
/usr/bin/python3 -c "import json; json.load(open('marketplace/index.json')); print('OK')"

# Unit tests
/usr/bin/python3 -m unittest tests.test_clauck_report -v

# Manual smoke test (requires gh auth)
clauck report "test report for watcher demo"
# After submission, answer Y at the watcher prompt
# Verify ~/.clauck/gh-watch-<N>.md was created with correct ISSUE_URL
# Verify `clauck list` shows the new job
```

## INTENT contract alignment

Serves **primitive 6 (orchestrate dependencies)** and **architectural property: self-observation feeds back** (INTENT.md §4). The watcher is a scheduled job that uses the existing scheduler — no new runtime mechanism required, consistent with §5 decision filter.