### PR TITLE
[#94] feat: clauck list --tag <name> filtering + tag visibility

### DIFF
--- a/lib/clauck
+++ b/lib/clauck
@@ -296,17 +296,33 @@ def cmd_next() -> None:
         print(f"  {name:<{name_w}}  {cron_display:<22}  {status}")
 
 
-def cmd_list() -> None:
+def cmd_list(tag_filter: str = "") -> None:
     m = load_manifest()
-    jobs = m.get("jobs", [])
-    if not jobs:
+    all_jobs = m.get("jobs", [])
+    if not all_jobs:
         print("No jobs registered.")
         return
+
+    if tag_filter:
+        tf = tag_filter.lower()
+        jobs = [j for j in all_jobs if tf in [t.lower() for t in j.get("tags", [])]]
+        if not jobs:
+            all_tags: set = set()
+            for j in all_jobs:
+                all_tags.update(j.get("tags", []))
+            print(f"  no jobs with tag: {tag_filter}")
+            if all_tags:
+                print(f"  available tags: {', '.join(sorted(all_tags))}")
+            return
+    else:
+        jobs = all_jobs
+
     for j in jobs:
         name = j["name"]
         cron = j.get("cron") or "(no cron)"
         desc = j.get("description", "")[:60]
         disabled = j.get("disabled", False)
+        tags = j.get("tags", [])
         state = job_state(name)
 
         status = "active"
@@ -324,7 +340,8 @@ def cmd_list() -> None:
         if "last_run" in state:
             extra += f"  last: {state['last_run']}"
 
-        print(f"  {name:<25} {cron:<20} [{status}]")
+        tags_str = f"  [{', '.join(tags)}]" if tags else ""
+        print(f"  {name:<25} {cron:<20} [{status}]{tags_str}")
         if desc:
             print(f"    {desc}")
         if extra:
@@ -3295,7 +3312,12 @@ def main() -> None:
     rest = args[1:]
 
     if cmd == "list":
-        cmd_list()
+        tag_filter = ""
+        if "--tag" in rest:
+            idx = rest.index("--tag")
+            if idx + 1 < len(rest):
+                tag_filter = rest[idx + 1]
+        cmd_list(tag_filter=tag_filter)
     elif cmd == "next":
         cmd_next()
     elif cmd == "status":


### PR DESCRIPTION
## Closes #94

## Motivation

As clauck job collections grow — especially with pipeline stage families (`pe-classify`, `pe-qa`, `pe-pipeline`) or related autonomy jobs (`delegate-scout`, `delegate-scout/ds-draft`) — the flat `clauck list` output becomes hard to navigate. Tags already exist in job frontmatter and the manifest, but `clauck list` ignores them entirely. The marketplace uses tags for browsing; the installed job list should too.

## Before / After

**Before:** `clauck list` shows name, cron, and status. No filtering. Tags invisible.

**After:**

```
$ clauck list
  heartbeat                0 * * * *            [active]
    Hourly pipeline liveness check.
  pe-classify              (no cron)            [active]  [pipeline, pe-stage]
    PE stage 1: intent classification.
  pe-qa                    (no cron)            [active]  [pipeline, pe-stage]
    PE stage 2: QA scoring.
  pe-pipeline              (no cron)            [active]  [pipeline, pe-root]
    PE root: 10-stage prompt enhancement.
  delegate-scout           */10 * * * *         [active]  [delegate, swarm, autonomous, slack]
    Swarm-safe autonomous delegate.

$ clauck list --tag pipeline
  pe-classify              (no cron)            [active]  [pipeline, pe-stage]
    PE stage 1: intent classification.
  pe-qa                    (no cron)            [active]  [pipeline, pe-stage]
    PE stage 2: QA scoring.
  pe-pipeline              (no cron)            [active]  [pipeline, pe-root]
    PE root: 10-stage prompt enhancement.

$ clauck list --tag nonexistent
  no jobs with tag: nonexistent
  available tags: autonomous, delegate, intent-mining, pe-root, pe-stage, pipeline, slack, swarm
```

## Cost / Value

- 27 lines added, 5 lines replaced — net +22 lines in one file. Zero new dependencies.
- Read-only, no side effects.
- Consistent with marketplace's tag-filter pattern (`clauck marketplace <tag>`) — same lowercase normalization, same "no match → show available" fallback.
- Jobs without tags: unaffected — no trailing bracket appended.

## Confidence / Impact

- Tags come directly from the manifest (already computed by scheduler.py on each tick). No log parsing, no additional I/O per job.
- `--tag` flag parsed with the same positional-index pattern used by `--last` in `cmd_logs`.
- Backwards compatible: `clauck list` with no args behaves identically to before for jobs without tags; for jobs with tags, tags appear at end of the status line.

## Validation Steps

```bash
# 1. Syntax check
/usr/bin/python3 -c "import ast; ast.parse(open('lib/clauck').read()); print('OK')"

# 2. Unfiltered list — existing jobs unchanged, tagged jobs show brackets
clauck list
# → name / cron / [status] rows as before; jobs with tags show [tag1, tag2] appended

# 3. Filtered list — only matching jobs shown
clauck list --tag pipeline    # if pe-pipeline family installed
# → only pe-* jobs

# 4. No-match path — helpful tag list shown
clauck list --tag nonexistent
# → "no jobs with tag: nonexistent"
# → "available tags: ..."

# 5. No tags at all — no crash, just the no-match message with no available-tags line
```

## INTENT contract alignment

Tags are part of the job's compiled metadata (primitive 2 — compile intent to durable work). Making them browsable closes the gap between having them and using them. Consistent with the marketplace pattern; no new architecture required.