### PR TITLE
fix(sizing): auto-promote haiku to sonnet when MCP surface is loaded

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,8 @@ Cost is a first-class transparent policy per `INTENT.md §3` non-negotiable #4 a
 
 **Auto-skew** — doctor tracks a `scale_skew` offset in config. When a doctor run hits its budget ceiling, the skew bumps (default +0.05, capped at +0.30); on clean runs it decays. Self-balancing safety net so the formula self-tunes to the user's real workloads without intervention.
 
+**MCP auto-promote** — empirical hard rule: if the user's full MCP surface loads (frontmatter does NOT set `strict_mcp_config: true`, or doctor stage-2 which always loads MCP), haiku auto-promotes to sonnet. The MCP surface (~150k tokens of tool descriptions) regularly approaches haiku's effective working context and triggers compaction loops that burn budget without progress. The promotion is surfaced in the sizing explanation string and via `clauck size <scale>`'s `strict_mcp:` line. To run a job on haiku, either set `strict_mcp_config: true` in frontmatter (the job won't have MCP tools available) or accept the sonnet bump.
+
 **Source of truth** — `lib/sizing.py` is the single implementation. `scheduler.py` and the CLI import from it. Do not introduce parallel cost/sizing logic anywhere else; if you need a different curve, edit `SCALE_PARAMS` or add knobs, don't bypass.
 
 ### Frontmatter schema (complete)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,8 @@ Cost is a first-class transparent policy per `INTENT.md §3` non-negotiable #4 a
 
 **MCP auto-promote** — empirical hard rule: if the user's full MCP surface loads (frontmatter does NOT set `strict_mcp_config: true`, or doctor stage-2 which always loads MCP), haiku auto-promotes to sonnet. The MCP surface (~150k tokens of tool descriptions) regularly approaches haiku's effective working context and triggers compaction loops that burn budget without progress. The promotion is surfaced in the sizing explanation string and via `clauck size <scale>`'s `strict_mcp:` line. To run a job on haiku, either set `strict_mcp_config: true` in frontmatter (the job won't have MCP tools available) or accept the sonnet bump.
 
+*Migration note:* installed jobs that previously derived haiku under MCP were silently truncating on the compaction loop; they now correctly route to sonnet. Per-run cost rises ~3–4× on those jobs, but runs actually complete. Jobs that explicitly strip MCP (`strict_mcp_config: true` in frontmatter) keep their prior haiku pricing unchanged.
+
 **Source of truth** — `lib/sizing.py` is the single implementation. `scheduler.py` and the CLI import from it. Do not introduce parallel cost/sizing logic anywhere else; if you need a different curve, edit `SCALE_PARAMS` or add knobs, don't bypass.
 
 ### Frontmatter schema (complete)

--- a/lib/clauck
+++ b/lib/clauck
@@ -1925,11 +1925,25 @@ def _validate_job_file(
                 findings.append(("error", f"complexity must be in [0.0, 1.0] (got {c})"))
             else:
                 has_complexity = True
-                sized = sizing.compute_sizing(c, 0, sizing.load_doctor_config())
+                # Route through resolve_params so the validator reports the
+                # same derivation the scheduler will actually produce — the
+                # scheduler reads strict_mcp_config from frontmatter and
+                # passes it through. Prior code called compute_sizing
+                # directly without the flag, so a job with strict_mcp_config:
+                # true would validate as "promoted to sonnet" but actually
+                # run on haiku — validator and runtime disagreed.
+                resolved = sizing.resolve_params(fm, 0, sizing.load_doctor_config())
+                sized_view = resolved.get("sizing") or {}
+                promo_note = (
+                    " [haiku auto-promoted → MCP surface]"
+                    if sized_view.get("mcp_promoted")
+                    else ""
+                )
                 findings.append((
                     "ok",
-                    f"complexity: {c} → derives {sized['model']}/{sized['effort']}, "
-                    f"{sized['max_turns']} turns, ${sized['max_budget_usd']:.2f} budget"
+                    f"complexity: {c} → derives {resolved['model']}/{resolved['effort']}, "
+                    f"{resolved['max_turns']} turns, ${float(resolved['max_budget_usd']):.2f} budget"
+                    f"{promo_note}"
                 ))
         except (ValueError, TypeError):
             findings.append(("error", f"complexity must be a number (got {raw_complexity!r})"))
@@ -4162,25 +4176,38 @@ def main() -> None:
     elif cmd == "size":
         if not rest:
             die("usage: clauck size <scale> [--ctx N] [--model auto|haiku|sonnet|opus] [--strict-mcp]")
-        size_scale = rest[0]
+        # Parse flags first (accepting them anywhere in the arglist), then
+        # take the first non-flag token as the positional scale. This
+        # allows `clauck size --strict-mcp 0.5` and `clauck size 0.5 --strict-mcp`
+        # to behave identically; the prior code took rest[0] verbatim and
+        # died with a spurious "expected float" when the flag was first.
+        size_strict_mcp = "--strict-mcp" in rest
         size_ctx = 0
         size_model = "auto"
-        size_strict_mcp = "--strict-mcp" in rest
-        i = 1
+        positionals: list[str] = []
+        i = 0
         while i < len(rest):
-            if rest[i] == "--ctx" and i + 1 < len(rest):
+            tok = rest[i]
+            if tok == "--strict-mcp":
+                i += 1
+            elif tok == "--ctx" and i + 1 < len(rest):
                 try:
                     size_ctx = int(rest[i + 1])
                 except ValueError:
                     die(f"--ctx expects an integer, got {rest[i + 1]!r}")
                 i += 2
-            elif rest[i] == "--model" and i + 1 < len(rest):
+            elif tok == "--model" and i + 1 < len(rest):
                 size_model = rest[i + 1]
                 i += 2
+            elif not tok.startswith("--"):
+                positionals.append(tok)
+                i += 1
             else:
                 i += 1
+        if not positionals:
+            die("usage: clauck size <scale> [--ctx N] [--model auto|haiku|sonnet|opus] [--strict-mcp]")
         cmd_size(
-            size_scale,
+            positionals[0],
             ctx_tokens=size_ctx,
             model_override=size_model,
             strict_mcp=size_strict_mcp,

--- a/lib/clauck
+++ b/lib/clauck
@@ -1474,6 +1474,7 @@ def cmd_size(
     scale_raw: str,
     ctx_tokens: int = 0,
     model_override: str = "auto",
+    strict_mcp: bool = False,
 ) -> None:
     """Show what the sizing formula derives for a given complexity scale.
 
@@ -1481,6 +1482,11 @@ def cmd_size(
     Useful when authoring a new job (`clauck size 0.35` tells you the derived
     model/turns/budget before you commit complexity: 0.35 to frontmatter) or
     debugging a surprising doctor sizing.
+
+    By default assumes `strict_mcp=False` — matching the common case where a
+    job loads the user's full MCP surface and haiku auto-promotes to sonnet.
+    Pass --strict-mcp to preview the haiku-eligible derivation for jobs with
+    `strict_mcp_config: true` in their frontmatter.
     """
     try:
         scale = float(scale_raw)
@@ -1490,7 +1496,7 @@ def cmd_size(
         die(f"scale {scale} out of range — must be in [0.0, 1.0]")
 
     cfg = sizing.load_doctor_config()
-    sized = sizing.compute_sizing(scale, int(ctx_tokens), cfg)
+    sized = sizing.compute_sizing(scale, int(ctx_tokens), cfg, strict_mcp=strict_mcp)
 
     if model_override != "auto" and model_override != sized["model"]:
         print(f"  note: formula picked {sized['model']}; your override = {model_override!r}")
@@ -1500,6 +1506,10 @@ def cmd_size(
     print(f"  scale:     {scale}")
     print(f"  skew:      {cfg.get('scale_skew', 0.0):+.2f} "
           f"(effective scale: {sized['scale_effective']:.2f})")
+    print(f"  strict_mcp: {strict_mcp}"
+          + ("  (haiku auto-promote ACTIVE)" if not strict_mcp else "  (haiku eligible)"))
+    if sized.get("mcp_promoted"):
+        print(f"  \u2191 haiku auto-promoted to {sized['model']} — MCP surface is loaded")
     print(f"  model:     {sized['model']}")
     print(f"  effort:    {sized['effort']}")
     print(f"  max_turns: {sized['max_turns']}")
@@ -2805,7 +2815,12 @@ def cmd_doctor(
         }
 
     interpretation = routing.get("interpretation", "Run diagnostic sweep")
-    sized = sizing.compute_sizing(scale, ctx_tokens, doctor_cfg)
+    # Doctor's stage-2 does NOT pass --strict-mcp-config — the diagnostic
+    # agent needs the user's MCP surface available (for --fix mode to post
+    # Slack escalations, query GitHub, etc.). So strict_mcp=False here,
+    # which lets compute_sizing auto-promote haiku → sonnet to avoid the
+    # compaction loop on MCP-heavy context.
+    sized = sizing.compute_sizing(scale, ctx_tokens, doctor_cfg, strict_mcp=False)
     exec_model = sized["model"]
     exec_effort = sized["effort"]
     exec_max_turns = str(sized["max_turns"])
@@ -4146,10 +4161,11 @@ def main() -> None:
         cmd_peek()
     elif cmd == "size":
         if not rest:
-            die("usage: clauck size <scale> [--ctx N] [--model auto|haiku|sonnet|opus]")
+            die("usage: clauck size <scale> [--ctx N] [--model auto|haiku|sonnet|opus] [--strict-mcp]")
         size_scale = rest[0]
         size_ctx = 0
         size_model = "auto"
+        size_strict_mcp = "--strict-mcp" in rest
         i = 1
         while i < len(rest):
             if rest[i] == "--ctx" and i + 1 < len(rest):
@@ -4163,7 +4179,12 @@ def main() -> None:
                 i += 2
             else:
                 i += 1
-        cmd_size(size_scale, ctx_tokens=size_ctx, model_override=size_model)
+        cmd_size(
+            size_scale,
+            ctx_tokens=size_ctx,
+            model_override=size_model,
+            strict_mcp=size_strict_mcp,
+        )
     elif cmd == "add" and rest:
         add_path = ""
         add_name = ""

--- a/lib/sizing.py
+++ b/lib/sizing.py
@@ -144,21 +144,57 @@ def scale_to_params(scale: float) -> tuple[str, str, int, float]:
 # ── Budget computation ─────────────────────────────────────────────────────
 
 
+def _promote_for_mcp(
+    model: str, effort: str, turns: int, rate: float
+) -> tuple[str, str, int, float, bool]:
+    """Auto-promote haiku → sonnet when MCP surface is loaded.
+
+    The user's full MCP surface (~150k tokens of tool descriptions) plus
+    settings/plugins overhead regularly approaches haiku's effective working
+    context, triggering compaction loops that burn the budget without making
+    progress. An empirical hard rule: if MCP is not stripped (either via
+    frontmatter `strict_mcp_config: true` or the CLI's `--strict-mcp-config`
+    flag), haiku is not a viable choice — promote to the sonnet band that
+    matches current effort intent.
+
+    Returns (new_model, new_effort, new_turns, new_rate, was_promoted).
+    Turns stays unchanged — we need a bigger MODEL, not more steps. Rate
+    comes from the first sonnet band matching `target_effort`, where haiku
+    `low` maps up to sonnet `medium` (the lightest sonnet tier exists).
+    """
+    if model != "haiku":
+        return model, effort, turns, rate, False
+    target_effort = effort if effort != "low" else "medium"
+    for _ceil, m, eff, _t, r in SCALE_PARAMS:
+        if m == "sonnet" and eff == target_effort:
+            return m, eff, turns, r, True
+    # Fallback: if no matching sonnet band found (shouldn't happen with
+    # current table), return first sonnet band regardless of effort.
+    for _ceil, m, eff, _t, r in SCALE_PARAMS:
+        if m == "sonnet":
+            return m, eff, turns, r, True
+    return model, effort, turns, rate, False  # no sonnet band — keep haiku
+
+
 def compute_sizing(
     scale: float,
     context_tokens: int,
     config: Optional[dict] = None,
+    strict_mcp: bool = False,
 ) -> dict:
     """Derive full sizing from a complexity scale and a rough context size.
 
     Returns a dict with keys:
         model, effort, max_turns, max_budget_usd,
         base_cost, context_cost, headroom, skew_applied, scale_effective,
+        mcp_promoted (bool — True when haiku was auto-promoted to sonnet),
         explanation (human-readable one-liner)
 
     Math:
         effective_scale = clamp(scale + scale_skew, 0, 1)
         (model, effort, turns, rate) = scale_to_params(effective_scale)
+        if not strict_mcp and model == "haiku":
+            (model, effort, turns, rate) = _promote_for_mcp(...)
         growth       = 1 + turns × context_growth_per_turn / 2   (midpoint avg)
         base_cost    = turns × rate × growth
         context_cost = turns × context_tokens × INPUT_RATE_PER_MTOK[model] / 1e6
@@ -169,6 +205,10 @@ def compute_sizing(
     midpoint-average multiplier over a session of N turns: if per-turn input
     grows by G×base each turn, the session-total cost is approximately
     N × base × (1 + N × G / 2), not N × base × (1 + N × G).
+
+    strict_mcp: pass True when the session will run under `--strict-mcp-config`
+    (empty MCP surface). False (default) assumes the user's full MCP surface
+    loads, which triggers the haiku → sonnet auto-promote.
     """
     # DEFAULT_DOCTOR_CONFIG is the single source of truth for fallbacks;
     # using a dict-merge means every key the user hasn't overridden comes
@@ -180,6 +220,12 @@ def compute_sizing(
     skew = float(cfg["scale_skew"] or 0.0)
     effective = _clamp_scale(float(scale) + skew)
     model, effort, turns, rate = scale_to_params(effective)
+
+    # Auto-promote haiku → sonnet when MCP surface is loaded — empirical
+    # rule to avoid haiku's compaction loop on MCP-heavy contexts.
+    model, effort, turns, rate, mcp_promoted = _promote_for_mcp(
+        model, effort, turns, rate
+    ) if not strict_mcp else (model, effort, turns, rate, False)
 
     growth = 1.0 + turns * float(cfg["context_growth_per_turn"]) / 2.0
     base_cost = turns * rate * growth
@@ -197,7 +243,9 @@ def compute_sizing(
     explanation = (
         f"scale={_clamp_scale(float(scale)):.2f}"
         + (f"+skew{skew:+.2f}" if abs(skew) > 1e-9 else "")
-        + f" → {model}/{effort}, {turns} turns, "
+        + f" → {model}/{effort}"
+        + (" (promoted from haiku: MCP loaded)" if mcp_promoted else "")
+        + f", {turns} turns, "
           f"base ${base_cost:.2f}"
         + (f" + ctx ${ctx_cost:.2f}" if ctx_cost >= 0.005 else "")
         + f" × {headroom:.2f} headroom = ${budget:.2f}"
@@ -214,6 +262,7 @@ def compute_sizing(
         "headroom": headroom,
         "skew_applied": skew,
         "scale_effective": effective,
+        "mcp_promoted": mcp_promoted,
         "explanation": explanation,
     }
 
@@ -259,10 +308,21 @@ def resolve_params(
     explicit_turns = fm_turns is not None
     explicit_budget = fm_budget is not None
 
+    # strict_mcp signal drives haiku auto-promote inside compute_sizing —
+    # when the frontmatter sets `strict_mcp_config: true`, the job runs
+    # without the user's MCP surface and haiku is safe. Absent or false,
+    # the full MCP surface loads and haiku is auto-promoted to sonnet.
+    strict_mcp_fm = bool(fm.get("strict_mcp_config", False))
+
     sizing = None
     if has_complexity:
         try:
-            sizing = compute_sizing(float(complexity_raw), int(context_tokens), config)
+            sizing = compute_sizing(
+                float(complexity_raw),
+                int(context_tokens),
+                config,
+                strict_mcp=strict_mcp_fm,
+            )
         except (TypeError, ValueError):
             sizing = None
 

--- a/lib/sizing.py
+++ b/lib/sizing.py
@@ -164,22 +164,28 @@ def _promote_for_mcp(
     """
     if model != "haiku":
         return model, effort, turns, rate, False
+    # haiku/low promotes to sonnet/medium (SCALE_PARAMS has no sonnet/low band
+    # — the lowest sonnet tier is medium). haiku/medium and haiku/high find
+    # exact effort matches in the sonnet bands.
     target_effort = effort if effort != "low" else "medium"
     for _ceil, m, eff, _t, r in SCALE_PARAMS:
         if m == "sonnet" and eff == target_effort:
             return m, eff, turns, r, True
-    # Fallback: if no matching sonnet band found (shouldn't happen with
-    # current table), return first sonnet band regardless of effort.
-    for _ceil, m, eff, _t, r in SCALE_PARAMS:
-        if m == "sonnet":
-            return m, eff, turns, r, True
-    return model, effort, turns, rate, False  # no sonnet band — keep haiku
+    # If we got here, SCALE_PARAMS has been reshuffled in a way that
+    # breaks the promotion contract. Raising is correct: we promised the
+    # caller an auto-promotion, and silently returning the wrong tier
+    # (or no promotion at all) would mask the table bug at runtime.
+    raise RuntimeError(
+        f"SCALE_PARAMS has no sonnet band matching effort {target_effort!r}; "
+        "cannot auto-promote haiku. Restore a sonnet/medium or sonnet/high band."
+    )
 
 
 def compute_sizing(
     scale: float,
     context_tokens: int,
     config: Optional[dict] = None,
+    *,
     strict_mcp: bool = False,
 ) -> dict:
     """Derive full sizing from a complexity scale and a rough context size.
@@ -223,9 +229,17 @@ def compute_sizing(
 
     # Auto-promote haiku → sonnet when MCP surface is loaded — empirical
     # rule to avoid haiku's compaction loop on MCP-heavy contexts.
-    model, effort, turns, rate, mcp_promoted = _promote_for_mcp(
-        model, effort, turns, rate
-    ) if not strict_mcp else (model, effort, turns, rate, False)
+    # Turns stays pinned to the scale-derived value: `scale` encoded the
+    # task's complexity, and turns tracked that. Promotion is a context-
+    # fit correction (haiku can't hold the MCP surface), not a complexity
+    # correction, so the task still takes the same number of steps — it
+    # just runs them on a model with more headroom.
+    if strict_mcp:
+        mcp_promoted = False
+    else:
+        model, effort, turns, rate, mcp_promoted = _promote_for_mcp(
+            model, effort, turns, rate
+        )
 
     growth = 1.0 + turns * float(cfg["context_growth_per_turn"]) / 2.0
     base_cost = turns * rate * growth

--- a/skill/clauck/SKILL.md
+++ b/skill/clauck/SKILL.md
@@ -596,6 +596,16 @@ complexity: 0.20
 strict_mcp_config: true    # skip MCP surface; haiku stays selected
 ```
 
+**Promotion mapping** (what the original band becomes when the bump fires):
+
+| Original (derived) | Promoted to |
+|---|---|
+| haiku / low | sonnet / medium  *(no sonnet/low band exists)* |
+| haiku / medium | sonnet / medium |
+| haiku / high | sonnet / high |
+
+Turns stay pinned to the scale-derived value — the task complexity hasn't changed, only the context-fit concern.
+
 Preview either path with `clauck size`:
 
 ```

--- a/skill/clauck/SKILL.md
+++ b/skill/clauck/SKILL.md
@@ -578,6 +578,33 @@ max_turns: 30    # override: this job consistently benefits from more turns
 
 Edit: `clauck config doctor scale_skew 0.1` (set) / `clauck config doctor` (view all).
 
+### MCP auto-promote (haiku ineligible when MCP loaded)
+
+Empirical hard rule in `sizing.py`: **haiku is not a viable choice when the user's full MCP surface is loaded.** Tool descriptions across a typical MCP surface total ~150k tokens — combined with system prompts and tool results, this regularly exceeds haiku's effective working context and sends sessions into a compaction loop that burns budget without progress.
+
+A job promotes automatically to sonnet if its frontmatter lacks `strict_mcp_config: true`:
+
+```yaml
+# no strict_mcp_config → scale 0.20 derives haiku → auto-promotes to sonnet
+complexity: 0.20
+```
+
+To keep haiku for cost, strip MCP explicitly:
+
+```yaml
+complexity: 0.20
+strict_mcp_config: true    # skip MCP surface; haiku stays selected
+```
+
+Preview either path with `clauck size`:
+
+```
+clauck size 0.20               # default: strict_mcp=False → sonnet
+clauck size 0.20 --strict-mcp  # haiku-eligible derivation
+```
+
+Doctor's stage-2 diagnostic session does NOT pass `--strict-mcp-config` (the agent needs MCP tools for `--fix` actions), so doctor runs auto-promote any haiku-tier scale up to sonnet.
+
 ### Auto-skew (self-tuning)
 
 When a doctor run hits `Reached maximum budget`, `scale_skew` bumps by `auto_skew_increment`, capped at `auto_skew_cap`. On clean (non-truncated) doctor runs, skew decays by half the increment, floored at 0. Self-balancing: raises when truncation happens, relaxes when things stabilize. Manual reset: `clauck config doctor scale_skew 0`.


### PR DESCRIPTION
## Summary

Empirical hard rule: **haiku is not a viable choice when the user's full MCP surface is loaded.** Tool descriptions across a typical MCP surface total ~150k tokens — combined with system prompts and tool results, this regularly exceeds haiku's effective working context and sends sessions into a compaction loop that burns budget without progress.

Follows directly from the conversation around PR #101: we added context-*cost* tracking (dollars per turn) but not context-*fit* guardrails (does everything load before compaction). This PR adds one minimal, explicit fit rule. A more sophisticated window-fit layer (MODEL_CONTEXT_WINDOW table + per-model thresholds + measure-once MCP estimate) is tracked as a follow-up if this rule proves insufficient in practice.

## What changed

- \`lib/sizing.py\` — new \`_promote_for_mcp\` helper + \`strict_mcp\` kwarg on \`compute_sizing\`. When \`strict_mcp=False\` (default), any haiku derivation bumps to the nearest sonnet band matching current effort (low→medium, medium→medium, high→high). Turns stay unchanged — we need a bigger **model**, not more steps. The promotion surfaces in the returned dict (\`mcp_promoted: bool\`) and in the \`explanation\` string.
- \`resolve_params\` — reads \`strict_mcp_config\` from frontmatter, passes through to \`compute_sizing\`.
- \`cmd_doctor\` — passes \`strict_mcp=False\` explicitly. Doctor's stage-2 does not pass \`--strict-mcp-config\` because the diagnostic agent needs MCP for \`--fix\` actions (post Slack escalations, query GitHub, etc.). So any haiku-tier scale auto-promotes. Eliminates the compaction-loop budget-exceeded failure mode that sparked PR #101 follow-up discussion.
- \`cmd_size\` — new \`--strict-mcp\` flag for preview, plus a \`strict_mcp:\` line and \`↑ haiku auto-promoted\` note in output.
- CLAUDE.md + SKILL.md — docs for the rule and how to opt out.

## Sanity check

| Frontmatter | Scale | Before this PR | After this PR |
|---|---|---|---|
| \`complexity: 0.20\` (MCP loaded, default) | 0.20 | haiku/high/8t/$0.22 | sonnet/high/8t/$0.77 |
| \`complexity: 0.20, strict_mcp_config: true\` | 0.20 | haiku/high/8t/$0.22 | haiku/high/8t/$0.22 (unchanged) |
| Doctor \"is plist loaded\" | 0.05 | haiku/low/3t/$0.05 | sonnet/medium/3t/$0.22 |
| \`complexity: 0.55\` (MCP loaded) | 0.55 | sonnet/medium/18t/$1.46 | sonnet/medium/18t/$1.46 (no promotion needed) |

## Test plan

- [x] \`ast.parse\` clean for all modules
- [x] ruff check passes (E9,F selection)
- [x] Smoke: resolve_params on fm with / without \`strict_mcp_config\` derives expected model
- [x] Smoke: compute_sizing with strict_mcp=False promotes haiku bands; with True keeps them
- [ ] After merge + reinstall: \`clauck size 0.20\` defaults to sonnet derivation; \`--strict-mcp\` shows haiku
- [ ] Doctor invocation that previously truncated on haiku now runs on sonnet and completes