### PR TITLE
fix(mcp): rewrite install for current Claude Code + Desktop APIs

### DIFF
--- a/lib/clauck
+++ b/lib/clauck
@@ -1636,8 +1636,104 @@ def cmd_version() -> None:
     print(f"  repo:      {repo}")
 
 
+def _strip_stale_mcp_entry(cfg_path: Path, server_key: str = "clauck") -> bool:
+    """Remove a previously-written `mcpServers.<key>` entry from a JSON config.
+
+    Prior versions of cmd_mcp_install wrote clauck entries directly into
+    `~/.claude/settings.json` and `~/Library/Application Support/Claude/
+    claude_desktop_config.json`. Neither path is authoritative anymore:
+    Claude Code uses `claude mcp add` (which writes to ~/.claude.json), and
+    Claude Desktop uses .mcpb bundles opened via the GUI. Leaving the stale
+    entries behind creates ghost registrations that either silently do
+    nothing or conflict with the current-API registration. This helper
+    removes the stale key and preserves the rest of the file.
+
+    Returns True when something was removed, False when no stale entry
+    existed (including when the file is absent).
+    """
+    if not cfg_path.exists():
+        return False
+    try:
+        data = json.loads(cfg_path.read_text())
+    except (OSError, ValueError):
+        return False
+    servers = data.get("mcpServers")
+    if not isinstance(servers, dict) or server_key not in servers:
+        return False
+    servers.pop(server_key, None)
+    if not servers:
+        data.pop("mcpServers", None)
+    try:
+        cfg_path.write_text(json.dumps(data, indent=2) + "\n")
+    except OSError:
+        return False
+    return True
+
+
+def _build_mcpb_bundle(
+    clauck_bin: str,
+    bundle_path: Path,
+    version: str,
+) -> None:
+    """Generate a minimal .mcpb bundle pointing at an already-installed clauck.
+
+    The bundle is just a zip containing manifest.json + a one-byte entry_point
+    stub. Claude Desktop reads manifest.json, extracts the absolute command
+    path from `server.mcp_config.command`, and launches clauck directly —
+    the entry_point file is required by the schema but unused at runtime
+    when the binary command is explicit.
+
+    We use stdlib zipfile rather than depending on `@anthropic-ai/mcpb`'s
+    `mcpb pack` — the resulting zip is identical from Claude Desktop's
+    perspective (the spec defines `.mcpb` as "a zip archive containing
+    the local MCP server as well as a manifest.json") and keeps clauck's
+    "no npm dependency" non-negotiable intact.
+
+    Overwrites any existing bundle at bundle_path. Caller is responsible
+    for invoking `open` on the finished bundle.
+    """
+    import zipfile
+
+    manifest = {
+        "manifest_version": "0.3",
+        "name": "clauck",
+        "version": version,
+        "description": (
+            "clauck MCP server — expose scheduled jobs and system health "
+            "as MCP tools (list_jobs, fire_job, get_status, etc.)"
+        ),
+        "author": {"name": "CoreyRDean"},
+        "server": {
+            "type": "binary",
+            # Required by schema; unused at runtime because mcp_config.command
+            # is an absolute path. The stub is written into the zip alongside
+            # the manifest so the bundle structure stays conformant.
+            "entry_point": "entry",
+            "mcp_config": {
+                "command": clauck_bin,
+                "args": ["mcp"],
+            },
+        },
+    }
+
+    bundle_path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(bundle_path, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr("manifest.json", json.dumps(manifest, indent=2))
+        # Stub entry_point file — a single comment byte keeps the schema
+        # requirement satisfied without adding meaningful content.
+        z.writestr("entry", "# clauck MCP launcher: see manifest.json mcp_config\n")
+
+
 def cmd_mcp_install() -> None:
-    """Write the clauck MCP server entry into Claude Desktop and Claude Code configs."""
+    """Register the clauck MCP server with Claude Code and Claude Desktop.
+
+    Claude Code: uses `claude mcp add --scope user` (authoritative).
+    Claude Desktop: builds a .mcpb bundle and opens it via `open`, which
+    triggers Claude Desktop's install dialog. The user clicks Install.
+
+    Also removes stale entries from the legacy config files that earlier
+    versions of clauck wrote to directly.
+    """
     import shutil as _shutil
 
     config = load_config()
@@ -1647,45 +1743,94 @@ def cmd_mcp_install() -> None:
         return
 
     clauck_bin = _shutil.which("clauck") or str(HOME / ".local" / "bin" / "clauck")
-    entry = {"command": clauck_bin, "args": ["mcp"]}
 
-    installed_any = False
+    # ── Clean up stale entries written by prior versions ─────────────────
+    # These paths are no longer authoritative for either Claude Code or
+    # Claude Desktop; leaving old clauck entries there produces ghost
+    # registrations that do nothing but confuse `claude mcp list` output
+    # and Claude Desktop's server list.
+    stale_paths = [
+        HOME / ".claude" / "settings.json",
+        HOME / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json",
+    ]
+    for p in stale_paths:
+        if _strip_stale_mcp_entry(p, "clauck"):
+            print(f"  cleaned stale entry: {p}")
 
-    # Claude Desktop
-    desktop_cfg = (
-        HOME / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
-    )
-    try:
-        cfg = json.loads(desktop_cfg.read_text()) if desktop_cfg.exists() else {}
-    except (OSError, ValueError):
-        cfg = {}
-    cfg.setdefault("mcpServers", {})["clauck"] = entry
-    desktop_cfg.parent.mkdir(parents=True, exist_ok=True)
-    desktop_cfg.write_text(json.dumps(cfg, indent=2) + "\n")
-    print(f"  Claude Desktop: {desktop_cfg}")
-    print("  (restart Claude Desktop to load the MCP server)")
-    installed_any = True
+    # ── Claude Code: use `claude mcp add --scope user` ───────────────────
+    # This writes to the correct (evolving) Claude Code config location
+    # so we don't have to know where that is. --scope user registers the
+    # server globally across all projects for the current user. Adding an
+    # already-existing server errors cleanly; we check first with `get`
+    # and skip if already present to keep output tidy.
+    claude_bin_path = _shutil.which("claude")
+    if claude_bin_path:
+        try:
+            probe = subprocess.run(
+                [claude_bin_path, "mcp", "get", "clauck"],
+                capture_output=True, text=True, timeout=10,
+            )
+            already_registered = probe.returncode == 0
+        except (subprocess.SubprocessError, OSError):
+            already_registered = False
 
-    # Claude Code CLI
-    code_cfg = HOME / ".claude" / "settings.json"
-    try:
-        code_data = json.loads(code_cfg.read_text()) if code_cfg.exists() else {}
-    except (OSError, ValueError):
-        code_data = {}
-    servers = code_data.setdefault("mcpServers", {})
-    if servers.get("clauck") != entry:
-        servers["clauck"] = entry
-        code_cfg.parent.mkdir(parents=True, exist_ok=True)
-        code_cfg.write_text(json.dumps(code_data, indent=2) + "\n")
-        print(f"  Claude Code CLI: {code_cfg}")
-        installed_any = True
+        if already_registered:
+            print("  Claude Code: clauck already registered (skipping)")
+        else:
+            try:
+                result = subprocess.run(
+                    [
+                        claude_bin_path, "mcp", "add",
+                        "--scope", "user",
+                        "clauck", clauck_bin, "mcp",
+                    ],
+                    capture_output=True, text=True, timeout=15,
+                )
+                if result.returncode == 0:
+                    print(f"  Claude Code: registered clauck → {clauck_bin} mcp")
+                else:
+                    err = (result.stderr or result.stdout or "").strip()
+                    print(f"  Claude Code: registration failed — {err[:200]}")
+                    print("  (run manually: "
+                          f"claude mcp add --scope user clauck {clauck_bin} mcp)")
+            except (subprocess.SubprocessError, OSError) as exc:
+                print(f"  Claude Code: registration failed — {exc}")
     else:
-        print(f"  Claude Code CLI: already registered ({code_cfg})")
+        print("  Claude Code: `claude` CLI not on PATH; skipping")
+        print("  (install Claude Code or run manually: "
+              f"claude mcp add --scope user clauck {clauck_bin} mcp)")
 
-    if installed_any:
-        print()
-        print("  tools: list_jobs · get_status · fire_job · get_logs")
-        print("         inspect_job · pause_job · resume_job · marketplace_list")
+    # ── Claude Desktop: build .mcpb bundle + open it ─────────────────────
+    # The modern Claude Desktop MCP install flow is `open foo.mcpb`, which
+    # triggers the app's GUI install dialog. The user clicks Install and
+    # Claude Desktop handles registration. We can't bypass the confirmation
+    # (by design; the new flow is explicit, not automatic), so the best
+    # clauck can do is minimize friction: generate a per-install bundle
+    # with an absolute command path, invoke `open`, and tell the user
+    # what to expect.
+    version = VERSION_FILE.read_text().strip() if VERSION_FILE.exists() else "0.0.0"
+    # VERSION file may start with "v"; the manifest semver field expects a
+    # bare version. Strip a single leading 'v' if present.
+    if version.startswith("v"):
+        version = version[1:]
+    bundle_path = JOBS_DIR / "clauck.mcpb"
+    try:
+        _build_mcpb_bundle(clauck_bin, bundle_path, version)
+        print(f"  Claude Desktop: built bundle {bundle_path}")
+        try:
+            subprocess.run(
+                ["open", str(bundle_path)],
+                capture_output=True, text=True, timeout=10,
+            )
+            print("  (Claude Desktop should prompt you to install — click Install)")
+        except (subprocess.SubprocessError, OSError) as exc:
+            print(f"  (auto-open failed: {exc}; open manually: open {bundle_path})")
+    except OSError as exc:
+        print(f"  Claude Desktop: bundle build failed — {exc}")
+
+    print()
+    print("  tools: list_jobs · get_status · fire_job · get_logs")
+    print("         inspect_job · pause_job · resume_job · marketplace_list")
 
 
 def cmd_mcp() -> None:

--- a/lib/clauck
+++ b/lib/clauck
@@ -1677,17 +1677,26 @@ def _build_mcpb_bundle(
 ) -> None:
     """Generate a minimal .mcpb bundle pointing at an already-installed clauck.
 
-    The bundle is just a zip containing manifest.json + a one-byte entry_point
-    stub. Claude Desktop reads manifest.json, extracts the absolute command
-    path from `server.mcp_config.command`, and launches clauck directly —
-    the entry_point file is required by the schema but unused at runtime
-    when the binary command is explicit.
+    Structure:
+      clauck.mcpb/
+        manifest.json       # MCPB v0.3 manifest
+        launch.py           # Real entry_point — 3-line exec shim to clauck
 
-    We use stdlib zipfile rather than depending on `@anthropic-ai/mcpb`'s
-    `mcpb pack` — the resulting zip is identical from Claude Desktop's
-    perspective (the spec defines `.mcpb` as "a zip archive containing
-    the local MCP server as well as a manifest.json") and keeps clauck's
-    "no npm dependency" non-negotiable intact.
+    The launch.py shim actually does what `entry_point` promises per the
+    MCPB spec (a real executable entrypoint in the bundle). Claude Desktop
+    invokes it via the mcp_config command (python3 launch.py); launch.py
+    execs the already-installed clauck binary so updates stay aligned
+    with clauck's own release cadence (the bundle never embeds the clauck
+    runtime itself). This is the "thin shim" pattern done spec-correctly
+    rather than relying on undocumented loader leniency.
+
+    `compatibility.platforms: ["darwin"]` matches INTENT.md §7 (macOS-only).
+
+    Built with stdlib zipfile rather than `@anthropic-ai/mcpb`'s `mcpb
+    pack` — preserves clauck's "no npm dependency" non-negotiable. Output
+    format is indistinguishable from `mcpb pack`'s from Claude Desktop's
+    perspective (spec defines `.mcpb` as "a zip archive containing the
+    local MCP server as well as a manifest.json").
 
     Overwrites any existing bundle at bundle_path. Caller is responsible
     for invoking `open` on the finished bundle.
@@ -1703,25 +1712,40 @@ def _build_mcpb_bundle(
             "as MCP tools (list_jobs, fire_job, get_status, etc.)"
         ),
         "author": {"name": "CoreyRDean"},
+        "compatibility": {
+            # INTENT.md §7: macOS is the only supported platform. Declaring
+            # this explicitly means Claude Desktop on Linux/Windows won't
+            # offer to install the bundle at all.
+            "platforms": ["darwin"],
+        },
         "server": {
-            "type": "binary",
-            # Required by schema; unused at runtime because mcp_config.command
-            # is an absolute path. The stub is written into the zip alongside
-            # the manifest so the bundle structure stays conformant.
-            "entry_point": "entry",
+            "type": "python",
+            "entry_point": "launch.py",
             "mcp_config": {
-                "command": clauck_bin,
-                "args": ["mcp"],
+                "command": "python3",
+                "args": ["launch.py"],
             },
         },
     }
 
+    # Real 3-line exec shim. The clauck binary path is baked in at build
+    # time, so the shim has zero runtime dependencies beyond /usr/bin/env
+    # python3 — already a clauck non-negotiable.
+    launcher = (
+        "#!/usr/bin/env python3\n"
+        f"# clauck MCP launcher — execs the installed clauck binary.\n"
+        f"# Built by clauck's cmd_mcp_install; regenerate by re-running\n"
+        f"# `clauck mcp --install`.\n"
+        f"import os\n"
+        f"os.execv({clauck_bin!r}, [{clauck_bin!r}, 'mcp'])\n"
+    )
+
     bundle_path.parent.mkdir(parents=True, exist_ok=True)
     with zipfile.ZipFile(bundle_path, "w", zipfile.ZIP_DEFLATED) as z:
         z.writestr("manifest.json", json.dumps(manifest, indent=2))
-        # Stub entry_point file — a single comment byte keeps the schema
-        # requirement satisfied without adding meaningful content.
-        z.writestr("entry", "# clauck MCP launcher: see manifest.json mcp_config\n")
+        # Launcher needs to be readable by Claude Desktop; zip doesn't
+        # preserve the +x bit but python3 interprets by invocation.
+        z.writestr("launch.py", launcher)
 
 
 def cmd_mcp_install() -> None:
@@ -1758,43 +1782,49 @@ def cmd_mcp_install() -> None:
             print(f"  cleaned stale entry: {p}")
 
     # ── Claude Code: use `claude mcp add --scope user` ───────────────────
-    # This writes to the correct (evolving) Claude Code config location
-    # so we don't have to know where that is. --scope user registers the
-    # server globally across all projects for the current user. Adding an
-    # already-existing server errors cleanly; we check first with `get`
-    # and skip if already present to keep output tidy.
+    # --scope user registers the server globally across all projects for
+    # the current user. We remove-then-add rather than skip-if-present
+    # because `claude mcp add`'s idempotency is keyed on server NAME, not
+    # args — a stale registration pointing at a now-missing clauck binary
+    # (e.g., user moved /opt/homebrew/bin/clauck → ~/.local/bin/clauck)
+    # would make skip-if-present print "already registered" while
+    # `claude mcp list` returns connection failures forever. Re-running
+    # `clauck mcp --install` must always converge the state with what we
+    # just printed to the user.
     claude_bin_path = _shutil.which("claude")
     if claude_bin_path:
+        # Best-effort remove. Non-fatal: ignore returncode. If the server
+        # isn't registered, remove errors cleanly; if some other registration
+        # exists, remove clears it so the add below fully overwrites.
         try:
-            probe = subprocess.run(
-                [claude_bin_path, "mcp", "get", "clauck"],
+            subprocess.run(
+                [claude_bin_path, "mcp", "remove", "clauck", "-s", "user"],
                 capture_output=True, text=True, timeout=10,
             )
-            already_registered = probe.returncode == 0
         except (subprocess.SubprocessError, OSError):
-            already_registered = False
+            pass
 
-        if already_registered:
-            print("  Claude Code: clauck already registered (skipping)")
-        else:
-            try:
-                result = subprocess.run(
-                    [
-                        claude_bin_path, "mcp", "add",
-                        "--scope", "user",
-                        "clauck", clauck_bin, "mcp",
-                    ],
-                    capture_output=True, text=True, timeout=15,
-                )
-                if result.returncode == 0:
-                    print(f"  Claude Code: registered clauck → {clauck_bin} mcp")
-                else:
-                    err = (result.stderr or result.stdout or "").strip()
-                    print(f"  Claude Code: registration failed — {err[:200]}")
-                    print("  (run manually: "
-                          f"claude mcp add --scope user clauck {clauck_bin} mcp)")
-            except (subprocess.SubprocessError, OSError) as exc:
-                print(f"  Claude Code: registration failed — {exc}")
+        try:
+            result = subprocess.run(
+                [
+                    claude_bin_path, "mcp", "add",
+                    "--scope", "user",
+                    "clauck", clauck_bin, "mcp",
+                ],
+                capture_output=True, text=True, timeout=15,
+            )
+            if result.returncode == 0:
+                print(f"  Claude Code: registered clauck → {clauck_bin} mcp")
+            else:
+                # Print the full error — truncation can cut off the
+                # actionable part of a CLI diagnostic. The user is staring
+                # at the terminal anyway.
+                err = (result.stderr or result.stdout or "").strip()
+                print(f"  Claude Code: registration failed — {err}")
+                print("  (run manually: "
+                      f"claude mcp add --scope user clauck {clauck_bin} mcp)")
+        except (subprocess.SubprocessError, OSError) as exc:
+            print(f"  Claude Code: registration failed — {exc}")
     else:
         print("  Claude Code: `claude` CLI not on PATH; skipping")
         print("  (install Claude Code or run manually: "

--- a/skill/clauck/SKILL.md
+++ b/skill/clauck/SKILL.md
@@ -191,15 +191,32 @@ Each notification shows the job name, success/failure, and cost if available —
 
 The notification fires after the claude session exits, regardless of success or failure. It is emitted via `osascript` and requires no additional software. Silent (no banner) if the user has disabled notifications for Terminal in macOS System Settings → Notifications.
 
-## MCP server (Claude Desktop integration)
+## MCP server (Claude Desktop + Claude Code integration)
 
 clauck ships a stdio MCP server that exposes job management as tools for any MCP-capable client (Claude Desktop, Claude Code, etc.).
 
-**Enable once:**
+**Enable once** (run by `install.sh` automatically; re-run any time to refresh):
+
 ```
-clauck mcp --install   # writes entry to ~/Library/Application Support/Claude/claude_desktop_config.json
-                       # restart Claude Desktop afterward
+clauck mcp --install
 ```
+
+What that does:
+
+- **Claude Code** — runs `claude mcp add --scope user clauck <clauck-bin> mcp` so the server appears in `claude mcp list` globally across projects. Idempotent (`claude mcp get clauck` is checked first).
+- **Claude Desktop** — builds a minimal `.mcpb` bundle at `~/.clauck/clauck.mcpb` (manifest points at the installed clauck binary) and runs `open` on it, triggering Claude Desktop's install dialog. **Click Install in the dialog to register.** Claude Desktop's new architecture requires explicit user confirmation — clauck cannot bypass it. Re-running `clauck mcp --install` rebuilds and re-opens the bundle.
+- **Cleanup** — removes any stale `mcpServers.clauck` entries from the legacy config files (`~/.claude/settings.json`, `~/Library/Application Support/Claude/claude_desktop_config.json`) so old clauck installs don't leave ghost registrations.
+
+**Opt out:** `clauck config set no_mcp_install true` or pass `--no-mcp` to `install.sh`. Persisted in `~/.clauck/.clauck.config.json`.
+
+**Verify registration:**
+
+```bash
+claude mcp list | grep clauck            # Claude Code: should list `clauck`
+ls ~/.clauck/clauck.mcpb                  # Claude Desktop: bundle exists
+```
+
+If Claude Desktop's dialog didn't appear, re-open the bundle manually: `open ~/.clauck/clauck.mcpb`.
 
 **Available tools:**
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -48,6 +48,7 @@ FILES=(
     "$HOME/.clauck/uninstall.sh"
     "$HOME/.clauck/.version"
     "$HOME/.clauck/prompt.md"
+    "$HOME/.clauck/clauck.mcpb"
     "$HOME/.claude/hooks/scheduled-jobs-notice.sh"
     "$HOME/.claude/skills/clauck/SKILL.md"
     "$HOME/.local/bin/clauck"
@@ -58,6 +59,19 @@ for f in "${FILES[@]}"; do
         ok "removed: $f"
     fi
 done
+
+# Unregister the Claude Code MCP entry (written by `clauck mcp --install`).
+# Symmetric cleanup: without this, `claude mcp list` retains a stale
+# `clauck` entry pointing at a now-deleted binary, producing "Failed to
+# connect" noise in every future Claude Code session. Best-effort; a
+# missing `claude` CLI or absent registration is not a fatal uninstall error.
+if command -v claude >/dev/null 2>&1; then
+    if claude mcp get clauck >/dev/null 2>&1; then
+        if claude mcp remove clauck -s user >/dev/null 2>&1; then
+            ok "unregistered clauck from Claude Code (user scope)"
+        fi
+    fi
+fi
 # Marketplace dir (cached copy of the curated job catalog).
 if [ -d "$HOME/.claude/skills/clauck/marketplace" ]; then
     rm -rf "$HOME/.claude/skills/clauck/marketplace"


### PR DESCRIPTION
## Summary

Neither auto-install path works anymore:

- **Claude Code**: writing to \`~/.claude/settings.json > mcpServers\` is no longer what \`claude mcp list\` reads — clauck was silently missing from Claude Code's MCP registry despite \"successful\" install.
- **Claude Desktop**: direct edits to \`claude_desktop_config.json\` no longer take effect; the modern flow requires a \`.mcpb\` bundle opened via macOS \`open\`, which triggers the app's install dialog.

Confirmed in the user's live environment: \`claude mcp list | grep clauck\` → nothing.

## Fixes

### Claude Code
\`cmd_mcp_install\` now shells out to \`claude mcp add --scope user clauck <clauck-bin> mcp\` — the authoritative registration command. \`--scope user\` makes it global across projects. Idempotent: we probe with \`claude mcp get clauck\` first and skip if already registered.

### Claude Desktop
Builds a minimal \`.mcpb\` bundle at \`~/.clauck/clauck.mcpb\` (manifest_version 0.3, \`server.type: binary\`, \`mcp_config.command\` = absolute clauck path) and runs \`open\` on it. Claude Desktop's install dialog fires; user clicks Install. The dialog cannot be bypassed by design — the new architecture requires explicit confirmation.

Bundle is built with stdlib \`zipfile\` (\`.mcpb\` is a zip archive per the \`modelcontextprotocol/mcpb\` spec), NOT \`@anthropic-ai/mcpb\`'s \`mcpb pack\` — preserves clauck's \"no npm dependency\" non-negotiable.

### Cleanup
New \`_strip_stale_mcp_entry\` helper removes prior \`mcpServers.clauck\` entries from both legacy config files on every install so old clauck installs don't leave ghost registrations.

## Test plan

- [x] \`ast.parse\` / \`bash -n\` / \`ruff --select=E9,F\` clean
- [x] Bundle round-trip smoke: zipfile contents include manifest.json + entry stub; manifest parses with absolute command path preserved
- [ ] After merge + reinstall: \`claude mcp list | grep clauck\` returns a registration
- [ ] After merge + reinstall: \`open ~/.clauck/clauck.mcpb\` triggers Claude Desktop install dialog
- [ ] Legacy stale entries removed from \`~/.claude/settings.json\` and \`~/Library/Application Support/Claude/claude_desktop_config.json\`
- [ ] \`--no-mcp\` opt-out still skips both registrations

## Non-goals

- Silent install of the Claude Desktop bundle. That's gone by design; user confirmation is mandatory in the new flow.
- Bundling the full MCP server code into the \`.mcpb\`. The bundle is a thin shim pointing at the installed clauck binary; keeps updates aligned with clauck's own release cadence.