### PR TITLE
fix(mcp): prefix launch.py with ${__dirname} in .mcpb args

### DIFF
--- a/lib/clauck
+++ b/lib/clauck
@@ -1723,7 +1723,15 @@ def _build_mcpb_bundle(
             "entry_point": "launch.py",
             "mcp_config": {
                 "command": "python3",
-                "args": ["launch.py"],
+                # ${__dirname} is the MCPB runtime variable that expands to
+                # the extracted bundle directory. Without it, Claude Desktop
+                # runs `python3 launch.py` from an arbitrary cwd (observed
+                # as `/` in practice), resolving to `//launch.py` → ENOENT.
+                # The Anthropic-shipped Filesystem MCP manifest uses this
+                # exact pattern (`${__dirname}/dist/index.js`), confirming
+                # it's the intended mechanism for referencing in-bundle
+                # entry points.
+                "args": ["${__dirname}/launch.py"],
             },
         },
     }


### PR DESCRIPTION
## Summary

PR #104's .mcpb bundle built manifests with a bare relative path:
\`\"args\": [\"launch.py\"]\`. Claude Desktop runs the subprocess with \`cwd = /\`,
so \`launch.py\` resolves to \`//launch.py\` and Python errors:

\`\`\`
/Applications/Xcode.app/Contents/Developer/usr/bin/python3: can't open file '//launch.py': [Errno 2] No such file or directory
\`\`\`

The server \"connects\" momentarily per Claude Desktop's handshake, then crashes on every invocation.

## Fix

Prefix the entry in \`args\` with \`\${__dirname}\` — MCPB's documented runtime variable that expands to the extracted bundle directory. One-line change in \`_build_mcpb_bundle\`.

## Evidence

Verified by reading the Anthropic-shipped Filesystem MCP manifest installed on the user's machine (\`~/Library/Application Support/Claude/Claude Extensions/ant.dir.ant.anthropic.filesystem/manifest.json\`), which uses the exact same pattern:

\`\`\`json
\"mcp_config\": {
  \"command\": \"node\",
  \"args\": [
    \"\${__dirname}/dist/index.js\",
    \"\${user_config.allowed_directories}\"
  ]
}
\`\`\`

## Test plan

- [x] Hot-patched the installed extension's \`manifest.json\` with the fix; user can verify immediately without re-installing by toggling the extension off/on in Claude Desktop
- [x] \`ast.parse\` / ruff / \`bash -n\` clean
- [ ] After merge + reinstall + re-open of \`clauck.mcpb\`: Claude Desktop logs show successful server startup (no \`//launch.py\` ENOENT)