### PR TITLE
fix(mcp): append semver build metadata so .mcpb reinstalls update cleanly

### DIFF
--- a/lib/clauck
+++ b/lib/clauck
@@ -1851,6 +1851,18 @@ def cmd_mcp_install() -> None:
     # bare version. Strip a single leading 'v' if present.
     if version.startswith("v"):
         version = version[1:]
+    # Append semver build metadata so every rebuild looks like a distinct
+    # version to Claude Desktop. Without this, re-opening the `.mcpb` after
+    # any code change (e.g., a manifest fix) is a silent no-op: Desktop
+    # sees the same `name` + `version` and keeps the already-installed
+    # (potentially stale) copy. Build metadata is semver-compliant
+    # (PEP 440-adjacent; `1.5.7+build.20260418T143059Z` is valid) and is
+    # ignored by precedence rules — it's the documented mechanism for
+    # "same release, different build" signaling. Timestamp granularity is
+    # seconds; two rebuilds in the same second shouldn't happen in any
+    # realistic install flow, but if they did, the second would no-op
+    # exactly as today.
+    version = f"{version}+build.{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
     bundle_path = JOBS_DIR / "clauck.mcpb"
     try:
         _build_mcpb_bundle(clauck_bin, bundle_path, version)


### PR DESCRIPTION
## Summary

Claude Desktop keys extension installs by \`name\` + \`version\`. With both unchanged across rebuilds, \`open clauck.mcpb\` silently keeps the already-installed copy — users who need a refreshed manifest (e.g., after #105's \${__dirname} fix) have to manually uninstall from the Claude Desktop UI before reinstall works.

## Fix

One-liner in \`_build_mcpb_bundle\`: append \`+build.<ISO timestamp>\` to the manifest version. Semver build metadata is ignored by precedence rules (so doesn't affect comparison) but IS part of the version string Desktop uses as the install key. Every rebuild is now a distinct version → \`open\` cleanly offers an update.

## Test plan

- [x] \`ast.parse\` / ruff clean
- [ ] After merge + reinstall: \`open ~/.clauck/clauck.mcpb\` prompts Claude Desktop to update (not no-op) without prior manual uninstall