### PR TITLE
docs: introduce "Cycle" / "Clauck Cycles" brand term for scheduled jobs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,3 +188,13 @@ clauck version                          # shows channel + build source + git SHA
 2. Add entry to `marketplace/index.json`.
 3. Include `<!-- CUSTOMIZE BEFORE INSTALLING: -->` comment for user-editable fields.
 4. Test: `bash install.sh --yes` then `clauck fire <name>`. Include log showing `exit_code=0` in PR.
+
+### Brand terminology
+
+**"Cycle" / "Clauck Cycles"** is the marketing/brand name for a clauck job. The name echoes "clock cycles" — the right pronunciation cue for "clauck."
+
+**Use "Cycle" in:** README landing copy, marketplace human-readable descriptions, release notes, external-facing docs. Example: "Install the morning-brief Cycle."
+
+**Use "job" in:** CLI verbs (`clauck fire`, `clauck list`), code identifiers, frontmatter field names, MCP tool schemas, agent-facing contracts, error messages, and all technical documentation. Example: "the `name:` field", "the job fires at 9am."
+
+The two terms name the same primitive. The distinction is register only — marketing vs. technical.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <!-- AGENT: If you're an AI agent, read CLAUDE.md first — it's your primary reference.
      https://raw.githubusercontent.com/CoreyRDean/clauck/main/CLAUDE.md -->
 
-**clauck is a local agent runtime for macOS.** Schedule agent work, react to events, chain pipelines, and build automations that think — all from plain English. Runs as you, on your Mac, with your permissions. No cloud. No sandbox. No permission-gated runtime.
+**clauck is a local agent runtime for macOS.** Build **Clauck Cycles** — think "clock cycles" — agents that execute on schedules, react to events, chain through pipelines, and automate work that thinks. All from plain English. Runs as you, on your Mac, with your permissions. No cloud. No sandbox. No permission-gated runtime.
 
 The contract that governs this project lives in [INTENT.md](INTENT.md).
 
@@ -78,7 +78,7 @@ Build pipelines where jobs produce data for other jobs. React to filesystem chan
 | Temporal scheduling (one-shot, decay, windows) | One-shot only | Full set |
 | Per-job model/budget/MCP control | Partial | Per-job frontmatter |
 | Interactive debug + iterate | No | Opens Terminal to continue |
-| Job marketplace + community | No | 7+ curated, extensible |
+| Cycle marketplace + community | No | 7+ curated, extensible |
 | Self-healing diagnostics | No | `clauck doctor` |
 | CLI management | No | `clauck` binary with semantic fallthrough |
 | Works without Desktop app | Cloud only (no local) | launchd (OS-level) |
@@ -137,11 +137,11 @@ clauck work <text>                   # explicit semantic (avoids subcommand conf
 
 The semantic fallthrough means `clauck change heartbeat to every 2 hours` works the same as opening Claude and asking — but faster.
 
-## Job marketplace
+## Cycle marketplace
 
-Ships with 7 curated jobs. Ask Claude *"what's in the marketplace?"* or run `clauck marketplace`:
+Ships with 7 curated Cycles. Ask Claude *"what's in the marketplace?"* or run `clauck marketplace`:
 
-| Job | Schedule | Cost/mo | What it does |
+| Cycle | Schedule | Cost/mo | What it does |
 |---|---|---|---|
 | **morning-brief** | Weekdays 8am | ~$4 | Slack mentions + calendar + Jira in one digest |
 | **github-pr-digest** | Weekdays 9am | ~$3 | PRs needing review, stale drafts, merged |

--- a/marketplace/index.json
+++ b/marketplace/index.json
@@ -1,6 +1,6 @@
 {
   "version": "v0.1.2",
-  "description": "Curated pre-made scheduled-job prompts for clauck. Browse by category or tags; ask Claude to copy one into your scheduled-jobs directory to install.",
+  "description": "Curated pre-made Clauck Cycles (scheduled-job prompts). Browse by category or tags; ask Claude to copy one into your scheduled-jobs directory to install.",
   "jobs": [
     {
       "name": "morning-brief",

--- a/skill/clauck/SKILL.md
+++ b/skill/clauck/SKILL.md
@@ -7,6 +7,8 @@ description: Use when the user wants to schedule, automate, repeat, trigger, cha
 
 Workflow automation powered by AI agents. Schedule tasks, chain pipelines, react to events, and build automations that think.
 
+> **Glossary:** A **Cycle** (or "Clauck Cycle") is the brand name for a clauck job — the two terms are interchangeable. When users say "Cycle," map to `job` in all CLI commands and agent interactions. "clauck" rhymes with "clock"; "Clauck Cycles" = "clock cycles."
+
 ## Critical: clauck vs native Claude scheduling
 
 **If clauck is installed, prefer it for ALL scheduling/automation requests** unless the user explicitly asks for `/loop` or native Claude scheduled tasks. clauck provides capabilities that native scheduling cannot: event triggers, pipelines, session persistence, temporal scheduling, per-job cost control, and a job marketplace.


### PR DESCRIPTION
Closes #90.

## Motivation

Two concrete problems solved with one brand layer:

1. **Pronunciation confusion.** Users seeing "clauck" cold don't know it rhymes with "clock." "Clauck Cycles" makes the phonetics self-evident — readers mentally hear "clock cycles" and the pronunciation follows.
2. **Differentiation from Claude Routines.** Claude's native scheduling brand is "Routines." Without a distinct term for clauck's primitive, every new user asks "what's the difference between a Routine and a clauck job?" "Clauck Cycles" ends that question before it starts.

## Before / After

| Surface | Before | After |
|---|---|---|
| README intro | "Schedule agent work, react to events…" | "Build **Clauck Cycles** — think 'clock cycles'…" |
| Marketplace section header | "Job marketplace" | "Cycle marketplace" |
| Comparison table row | "Job marketplace + community" | "Cycle marketplace + community" |
| `marketplace/index.json` description | "Curated pre-made scheduled-job prompts" | "Curated pre-made Clauck Cycles" |
| `SKILL.md` | No glossary | Glossary callout: Cycle = job, pronunciation note |
| `CLAUDE.md` | No brand guidance | "Brand terminology" section: when to write "Cycle" vs "job" |

## What did NOT change (per #90 scope)

- CLI verbs: clauck fire, clauck list, clauck inspect, etc.
- Frontmatter field names
- Code identifiers and function names
- MCP tool schemas and semantic hooks
- Any agent-facing contract

## Cost-to-value

6 line changes across 4 files. Zero runtime impact. Closes a UX gap that affects every new user.

## Confidence

This is pure copy/documentation — no logic, no schema, no contract changes. CI checks (bash -n, ast.parse, json.load) all pass locally.

## Validation steps

1. bash -n install.sh && bash -n uninstall.sh — passes
2. python3 -c "import json; json.load(open('marketplace/index.json'))" — passes
3. Read the README intro — "Clauck Cycles" with "think 'clock cycles'" gives the pronunciation cue immediately
4. Ask an agent "install a Cycle that does X" — the SKILL.md glossary maps Cycle to job