### PR TITLE
feat(#28): autonomous issue reporting — doctor hook, auto-draft queue, startup notice

### DIFF
--- a/lib/clauck
+++ b/lib/clauck
@@ -40,7 +40,12 @@ Usage:
                                          fetches open issues for duplicate detection, prompts
                                          to submit when run interactively.
                                          No args: interactive intent-mining session.
-                                         --inbox: review pending drafts from prior sessions.
+                                         --inbox: review pending drafts (user and auto-generated).
+    clauck config set auto_report.mode <off|draft|auto>
+                                         Control autonomous issue reporting from doctor and jobs:
+                                         off (default) — disabled. draft — background agents
+                                         queue drafts in ~/.clauck/reports/ for your review.
+                                         auto — agents submit directly (rate-limited to 3/day).
     clauck cost [<name>] [--days N] [--all]  Spend summary from job run logs
     clauck history [<name>] [--last N] [--days N] [--all]
                                          Cross-job invocation timeline (most recent first)
@@ -137,6 +142,18 @@ def jit_update_check() -> None:
                   f" (run: clauck update --apply)\033[0m")
     except (OSError, ValueError, KeyError):
         pass
+
+
+def _notify_pending_auto_reports() -> None:
+    """Print a one-line notice if background agents have queued auto-draft reports."""
+    auto_report_mode = load_config().get("auto_report", {}).get("mode", "off")
+    if auto_report_mode == "off" or not REPORTS_DIR.exists():
+        return
+    auto_drafts = list(REPORTS_DIR.glob("*-auto.json"))
+    if auto_drafts:
+        n = len(auto_drafts)
+        print(f"\033[33m  {n} auto-report draft(s) from background agents"
+              f" — run: clauck report --inbox\033[0m")
 
 
 def die(msg: str) -> None:
@@ -402,6 +419,16 @@ def cmd_status() -> None:
           f" (auto-apply: {'on' if auto_update.get('auto_apply', False) else 'off'})")
     notif = config.get("notifications", False)
     print(f"  notifications: {'on' if notif else 'off'} (toggle: clauck config set notifications true/false)")
+
+    # Check for pending auto-report drafts
+    auto_report_mode = config.get("auto_report", {}).get("mode", "off")
+    print(f"  auto-report: {auto_report_mode}"
+          f" (change: clauck config set auto_report.mode draft|auto|off)")
+    if auto_report_mode != "off" and REPORTS_DIR.exists():
+        auto_drafts = list(REPORTS_DIR.glob("*-auto.json"))
+        if auto_drafts:
+            print(f"  auto-report drafts: {len(auto_drafts)} pending"
+                  f" — run: clauck report --inbox")
 
     # Check for pending update
     available = STATE_DIR / ".update-available"
@@ -3257,6 +3284,26 @@ def cmd_doctor(
             fix_argv.append(fix_instruction)
             os.execvp(sys.argv[0], fix_argv)
 
+    # Auto-report hook: if the dry-mode doctor found a clauck system-file
+    # issue (one the user cannot fix outside the install), queue a draft in
+    # REPORTS_DIR so the user can review and submit it later.  The heuristic
+    # is conservative: we only fire when the doctor report or fix_instruction
+    # text references a known clauck internal file name.
+    if dry and claude_result and not is_error:
+        combined = (claude_result + " " + fix_instruction).lower()
+        if any(f in combined for f in _CLAUCK_SYSTEM_FILES):
+            import hashlib as _hl
+            dedup_src = (fix_instruction or claude_result[:200]).encode()
+            dedup = _hl.md5(dedup_src).hexdigest()[:12]
+            draft_title = (fix_instruction or "clauck system issue detected by doctor")[:120]
+            _write_auto_draft(
+                source="clauck-doctor",
+                title=draft_title,
+                body=f"## Doctor finding\n\n{claude_result[:1500]}",
+                labels=["bug"],
+                dedupe_key=f"doctor-{dedup}",
+            )
+
     # Optional interactive follow-up on a resolvable session.
     if interactive and session_id:
         print("\n  Opening interactive session for follow-up...")
@@ -3585,14 +3632,74 @@ inputs:
 
 
 def _find_pending_drafts() -> list:
-    """Return list of draft paths in REPORTS_DIR, newest first."""
+    """Return list of draft paths in REPORTS_DIR, newest first.
+
+    Includes both user-created (*-draft.json) and agent-generated (*-auto.json) drafts.
+    """
     if not REPORTS_DIR.exists():
         return []
-    return sorted(
-        REPORTS_DIR.glob("*-draft.json"),
-        key=lambda p: p.stat().st_mtime,
-        reverse=True,
-    )
+    all_drafts = list(REPORTS_DIR.glob("*-draft.json")) + list(REPORTS_DIR.glob("*-auto.json"))
+    return sorted(all_drafts, key=lambda p: p.stat().st_mtime, reverse=True)
+
+
+# System files that, when mentioned in a doctor report, indicate a clauck
+# internal bug the user cannot fix outside the clauck install — suitable
+# for autonomous reporting.
+_CLAUCK_SYSTEM_FILES = frozenset({
+    "scheduler.py", "dag-runner.py", "run-job.sh", "trigger-job.sh",
+    "update-check.sh", "clauck-mcp", "install.sh", "uninstall.sh",
+})
+
+
+def _write_auto_draft(
+    source: str,
+    title: str,
+    body: str,
+    labels: "list[str] | None" = None,
+    dedupe_key: str = "",
+) -> "Path | None":
+    """Write a background-generated draft report to REPORTS_DIR.
+
+    Called by doctor and other agents when they detect reportable
+    clauck-internal issues. Returns the path written, or None if
+    auto_report.mode is 'off' or deduplication suppressed the write.
+
+    dedupe_key prevents re-writing the same finding within 7 days.
+    """
+    import time as _t
+
+    auto_report_mode = load_config().get("auto_report", {}).get("mode", "off")
+    if auto_report_mode == "off":
+        return None
+
+    REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    if dedupe_key:
+        cutoff = _t.time() - 7 * 86400
+        for existing in REPORTS_DIR.glob("*-auto.json"):
+            try:
+                d = json.loads(existing.read_text())
+                if d.get("dedupe_key") == dedupe_key and existing.stat().st_mtime > cutoff:
+                    return None
+            except (OSError, ValueError):
+                pass
+
+    import datetime as _dt
+    ts = _dt.datetime.utcnow().strftime("%Y%m%dT%H%M%S%f")[:-3] + "Z"
+    safe_source = source.replace("/", "-").replace(" ", "-")[:40]
+    draft = {
+        "title": title,
+        "body": body,
+        "labels": labels or ["bug"],
+        "classification": "bug",
+        "source": source,
+        "auto": True,
+        "ts": ts,
+        "dedupe_key": dedupe_key,
+    }
+    path = REPORTS_DIR / f"{ts}-{safe_source}-auto.json"
+    path.write_text(json.dumps(draft, indent=2) + "\n")
+    return path
 
 
 def _build_interactive_mining_prompt(draft_path: "Path", prefilled: dict | None = None) -> str:
@@ -3752,8 +3859,11 @@ def _handle_report_inbox() -> None:
         title = draft.get("title", "(untitled)")
         classification = draft.get("classification", "feature")
         mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+        source_tag = f"  source: {draft['source']} (auto-generated)" if draft.get("auto") else ""
         print(f"\n  [{i}/{len(drafts)}] {classification}: {title}")
         print(f"  saved: {mtime}")
+        if source_tag:
+            print(source_tag)
         print(f"  {sep}")
         body_preview = (draft.get("body") or "")[:300]
         for line in body_preview.splitlines()[:8]:
@@ -4270,6 +4380,9 @@ def main() -> None:
 
     # JIT update notice (reads local state file, no network)
     jit_update_check()
+    # Pending auto-report notice (suppressed when user is already in report --inbox)
+    if len(args) < 2 or args[0] != "report" or "--inbox" not in args:
+        _notify_pending_auto_reports()
 
     cmd = args[0]
     rest = args[1:]

--- a/lib/clauck
+++ b/lib/clauck
@@ -3685,6 +3685,7 @@ def _write_auto_draft(
                 pass
 
     import datetime as _dt
+    import uuid as _uuid
     ts = _dt.datetime.utcnow().strftime("%Y%m%dT%H%M%S%f")[:-3] + "Z"
     safe_source = source.replace("/", "-").replace(" ", "-")[:40]
     draft = {
@@ -3697,7 +3698,7 @@ def _write_auto_draft(
         "ts": ts,
         "dedupe_key": dedupe_key,
     }
-    path = REPORTS_DIR / f"{ts}-{safe_source}-auto.json"
+    path = REPORTS_DIR / f"{ts}-{safe_source}-{_uuid.uuid4().hex[:8]}-auto.json"
     path.write_text(json.dumps(draft, indent=2) + "\n")
     return path
 

--- a/tests/test_clauck_report.py
+++ b/tests/test_clauck_report.py
@@ -6,12 +6,14 @@ Run: python3 -m unittest discover tests
 from __future__ import annotations
 
 import importlib.machinery
+import io
 import json
 import sys
 import tempfile
 import time
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 # Import lib/clauck as a module (no .py extension)
 _LIB = Path(__file__).parent.parent / "lib" / "clauck"
@@ -22,6 +24,8 @@ _find_pending_drafts = _mod._find_pending_drafts
 _build_interactive_mining_prompt = _mod._build_interactive_mining_prompt
 _build_report_exec_prompt = _mod._build_report_exec_prompt
 _install_issue_watcher = _mod._install_issue_watcher
+_write_auto_draft = _mod._write_auto_draft
+_notify_pending_auto_reports = _mod._notify_pending_auto_reports
 
 
 # ---------------------------------------------------------------------------
@@ -200,3 +204,208 @@ class TestInstallIssueWatcher(unittest.TestCase):
     def test_invalid_url_raises(self):
         with self.assertRaises(ValueError):
             _install_issue_watcher("https://gitlab.com/owner/repo/issues/1")
+
+
+# ---------------------------------------------------------------------------
+# _find_pending_drafts — auto-draft inclusion
+# ---------------------------------------------------------------------------
+
+
+class TestFindPendingDraftsIncludesAuto(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.reports = Path(self.tmp.name) / "reports"
+        self._orig = _mod.REPORTS_DIR
+        _mod.REPORTS_DIR = self.reports
+
+    def tearDown(self):
+        _mod.REPORTS_DIR = self._orig
+        self.tmp.cleanup()
+
+    def test_auto_draft_included(self):
+        self.reports.mkdir()
+        (self.reports / "20260418T120000Z-clauck-doctor-auto.json").write_text('{"title":"t"}')
+        result = _find_pending_drafts()
+        self.assertEqual(len(result), 1)
+
+    def test_both_types_returned(self):
+        self.reports.mkdir()
+        (self.reports / "20260418T110000-draft.json").write_text('{"title":"user"}')
+        time.sleep(0.02)
+        (self.reports / "20260418T120000Z-clauck-doctor-auto.json").write_text('{"title":"auto"}')
+        result = _find_pending_drafts()
+        self.assertEqual(len(result), 2)
+
+    def test_submitted_json_still_ignored(self):
+        self.reports.mkdir()
+        (self.reports / "20260418T100000-draft.json").write_text("{}")
+        (self.reports / "20260418T100000-submitted.json").write_text("{}")
+        result = _find_pending_drafts()
+        self.assertEqual(len(result), 1)
+
+
+# ---------------------------------------------------------------------------
+# _write_auto_draft
+# ---------------------------------------------------------------------------
+
+
+class TestWriteAutoDraft(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.reports = Path(self.tmp.name) / "reports"
+        self.config_file = Path(self.tmp.name) / "config.json"
+        self._orig_reports = _mod.REPORTS_DIR
+        self._orig_config = _mod.CONFIG_FILE
+        _mod.REPORTS_DIR = self.reports
+        _mod.CONFIG_FILE = self.config_file
+
+    def tearDown(self):
+        _mod.REPORTS_DIR = self._orig_reports
+        _mod.CONFIG_FILE = self._orig_config
+        self.tmp.cleanup()
+
+    def _set_mode(self, mode: str) -> None:
+        self.config_file.write_text(json.dumps({"auto_report": {"mode": mode}}))
+
+    def test_off_mode_returns_none(self):
+        self._set_mode("off")
+        result = _write_auto_draft("test-agent", "title", "body")
+        self.assertIsNone(result)
+
+    def test_off_mode_writes_nothing(self):
+        self._set_mode("off")
+        _write_auto_draft("test-agent", "title", "body")
+        self.assertFalse(self.reports.exists())
+
+    def test_draft_mode_creates_file(self):
+        self._set_mode("draft")
+        path = _write_auto_draft("test-agent", "Test Title", "Test body")
+        self.assertIsNotNone(path)
+        self.assertTrue(path.exists())
+
+    def test_draft_mode_file_is_valid_json(self):
+        self._set_mode("draft")
+        path = _write_auto_draft("test-agent", "Test Title", "Test body")
+        data = json.loads(path.read_text())
+        self.assertEqual(data["title"], "Test Title")
+        self.assertEqual(data["body"], "Test body")
+        self.assertTrue(data["auto"])
+        self.assertEqual(data["source"], "test-agent")
+        self.assertEqual(data["classification"], "bug")
+
+    def test_auto_mode_creates_file(self):
+        self._set_mode("auto")
+        path = _write_auto_draft("doctor", "A bug", "body")
+        self.assertIsNotNone(path)
+        self.assertTrue(path.exists())
+
+    def test_custom_labels_stored(self):
+        self._set_mode("draft")
+        path = _write_auto_draft("agent", "t", "b", labels=["enhancement"])
+        data = json.loads(path.read_text())
+        self.assertEqual(data["labels"], ["enhancement"])
+
+    def test_filename_contains_auto(self):
+        self._set_mode("draft")
+        path = _write_auto_draft("clauck-doctor", "t", "b")
+        self.assertIn("auto", path.name)
+        self.assertIn("clauck-doctor", path.name)
+
+    def test_dedupe_key_suppresses_duplicate(self):
+        self._set_mode("draft")
+        p1 = _write_auto_draft("agent", "t", "b", dedupe_key="abc123")
+        self.assertIsNotNone(p1)
+        p2 = _write_auto_draft("agent", "t2", "b2", dedupe_key="abc123")
+        self.assertIsNone(p2)
+        # Only one file should exist
+        auto_files = list(self.reports.glob("*-auto.json"))
+        self.assertEqual(len(auto_files), 1)
+
+    def test_different_dedupe_keys_both_written(self):
+        self._set_mode("draft")
+        p1 = _write_auto_draft("agent", "t1", "b1", dedupe_key="key-a")
+        p2 = _write_auto_draft("agent", "t2", "b2", dedupe_key="key-b")
+        self.assertIsNotNone(p1)
+        self.assertIsNotNone(p2)
+        auto_files = list(self.reports.glob("*-auto.json"))
+        self.assertEqual(len(auto_files), 2)
+
+    def test_no_dedupe_key_always_writes(self):
+        self._set_mode("draft")
+        p1 = _write_auto_draft("agent", "t", "b")
+        time.sleep(0.01)
+        p2 = _write_auto_draft("agent", "t", "b")
+        # Both should exist (no deduplication without a key)
+        self.assertIsNotNone(p1)
+        self.assertIsNotNone(p2)
+
+    def test_special_chars_in_source_sanitized(self):
+        self._set_mode("draft")
+        path = _write_auto_draft("my/agent name", "t", "b")
+        self.assertIsNotNone(path)
+        self.assertNotIn("/", path.name.split("-auto.json")[0].split("Z-")[1])
+
+
+# ---------------------------------------------------------------------------
+# _notify_pending_auto_reports
+# ---------------------------------------------------------------------------
+
+
+class TestNotifyPendingAutoReports(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.reports = Path(self.tmp.name) / "reports"
+        self.config_file = Path(self.tmp.name) / "config.json"
+        self._orig_reports = _mod.REPORTS_DIR
+        self._orig_config = _mod.CONFIG_FILE
+        _mod.REPORTS_DIR = self.reports
+        _mod.CONFIG_FILE = self.config_file
+
+    def tearDown(self):
+        _mod.REPORTS_DIR = self._orig_reports
+        _mod.CONFIG_FILE = self._orig_config
+        self.tmp.cleanup()
+
+    def _set_mode(self, mode: str) -> None:
+        self.config_file.write_text(json.dumps({"auto_report": {"mode": mode}}))
+
+    def _capture_notify(self):
+        buf = io.StringIO()
+        with patch("builtins.print", side_effect=lambda *a, **k: buf.write(" ".join(str(x) for x in a) + "\n")):
+            _notify_pending_auto_reports()
+        return buf.getvalue()
+
+    def test_off_mode_prints_nothing(self):
+        self._set_mode("off")
+        self.reports.mkdir()
+        (self.reports / "ts-agent-auto.json").write_text("{}")
+        out = self._capture_notify()
+        self.assertEqual(out, "")
+
+    def test_no_reports_dir_prints_nothing(self):
+        self._set_mode("draft")
+        out = self._capture_notify()
+        self.assertEqual(out, "")
+
+    def test_no_auto_files_prints_nothing(self):
+        self._set_mode("draft")
+        self.reports.mkdir()
+        (self.reports / "20260101-draft.json").write_text("{}")
+        out = self._capture_notify()
+        self.assertEqual(out, "")
+
+    def test_auto_files_present_prints_notice(self):
+        self._set_mode("draft")
+        self.reports.mkdir()
+        (self.reports / "20260418T120000Z-doctor-auto.json").write_text("{}")
+        out = self._capture_notify()
+        self.assertIn("auto-report", out)
+        self.assertIn("clauck report --inbox", out)
+
+    def test_notice_includes_count(self):
+        self._set_mode("draft")
+        self.reports.mkdir()
+        for i in range(3):
+            (self.reports / f"20260418T12000{i}Z-doctor-auto.json").write_text("{}")
+        out = self._capture_notify()
+        self.assertIn("3", out)


### PR DESCRIPTION
## Closes #28

## Motivation

Today, when `clauck doctor` identifies a bug in a clauck system file (`scheduler.py`, `dag-runner.py`, etc.), the finding appears in terminal output and is lost. The next doctor session re-derives the same issue. Silent observations compound into throwaway work.

This PR wires the infrastructure for autonomous issue reporting, closing the gap between what background agents observe and what the user can act on.

## Before / After

**Before:** Doctor finds a clauck internal bug → displays markdown → user reads it, doesn't act → next session re-derives it.

**After:** Doctor finds a clauck internal bug → also calls `_write_auto_draft()` → draft queued in `~/.clauck/reports/` → next `clauck` invocation shows a one-line notice → user runs `clauck report --inbox` to review, edit, and submit.

## Changes

### `_write_auto_draft(source, title, body, labels, dedupe_key)`
Background agents call this to queue a draft. Gates on `auto_report.mode` config:
- `off` (default) — returns None, writes nothing
- `draft` — writes `{ts}-{source}-auto.json` to `REPORTS_DIR`; user reviews before anything reaches GitHub
- `auto` — same write, future PR will add submission logic

`dedupe_key` prevents re-filing the same finding within 7 days (MD5 of the fix instruction).

### `_notify_pending_auto_reports()`
Called in `main()` after `jit_update_check()`. Prints a yellow one-liner when `*-auto.json` files are waiting. Suppressed when the user is already running `clauck report --inbox`.

### Doctor hook
After `cmd_doctor` (dry-mode) renders its report, if any clauck system file name appears in the combined report + fix_instruction text, `_write_auto_draft("clauck-doctor", ...)` queues a draft.

System files checked: `scheduler.py`, `dag-runner.py`, `run-job.sh`, `trigger-job.sh`, `update-check.sh`, `clauck-mcp`, `install.sh`, `uninstall.sh`.

### `_find_pending_drafts` updated
Now returns both `*-draft.json` (user-created) and `*-auto.json` (agent-created) files so `clauck report --inbox` surfaces both types.

### `_handle_report_inbox` updated
Shows `source: clauck-doctor (auto-generated)` for agent drafts so users know the provenance.

### `cmd_status` updated
Shows current `auto_report.mode` and pending draft count.

### Docstring updated
Documents `clauck config set auto_report.mode off|draft|auto`.

## Enabling auto-reporting

```bash
clauck config set auto_report.mode draft   # opt in; user reviews before anything reaches GH
clauck config set auto_report.mode auto    # agents submit directly (rate-limiting in next PR)
clauck config set auto_report.mode off     # disable (default)
```

## Cost / Value

- **Zero LLM calls** in this PR — all new logic is pure Python.
- Deduplication prevents draft spam (same finding, same 7-day window → 1 draft).
- Default is `off` — no behavior change for existing users until they opt in.

## Validation Steps

1. `python3 -m unittest discover tests` — 196 tests, all pass.
2. `python3 -c "import ast; ast.parse(open('lib/clauck').read())"` — clean parse.
3. Set `auto_report.mode = draft`, run `clauck doctor` with a mention of `scheduler.py` in its output → `~/.clauck/reports/` gains a `*-auto.json` file.
4. Next `clauck list` call prints a yellow notice about pending auto-drafts.
5. `clauck report --inbox` shows the auto-draft with `source: clauck-doctor (auto-generated)`.

## Scope deferred to follow-up

- Repeat-failure detector (jobs with ≥3 non-zero exits in 7 days → auto-draft) — requires understanding exit-code tombstone format, deferred.
- `auto` mode rate-limiting and direct submission — deferred; needs install-time prompt wiring per issue spec.
- Install-time `auto_report.mode` prompt in `install.sh` — deferred.