### PR TITLE
test(#113): unit tests for cron helpers and next-fire formatting in lib/clauck

### DIFF
--- a/tests/test_clauck.py
+++ b/tests/test_clauck.py
@@ -1,0 +1,225 @@
+"""Unit tests for budget circuit-breaker tombstone helpers in lib/clauck.
+
+Covers: _format_age, _tombstone_age_hours, _list_tombstones, _find_tombstone.
+
+Run: python3 -m pytest tests/test_clauck.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+# lib/clauck has a shebang and no .py extension; spec_from_file_location
+# cannot infer the loader without an extension, so use SourceFileLoader directly.
+import importlib.machinery
+_CLAUCK_PATH = Path(__file__).parent.parent / "lib" / "clauck"
+_loader = importlib.machinery.SourceFileLoader("clauck", str(_CLAUCK_PATH))
+_spec = importlib.util.spec_from_loader("clauck", _loader)
+clauck = importlib.util.module_from_spec(_spec)
+_loader.exec_module(clauck)
+
+
+# ---------------------------------------------------------------------------
+# _format_age
+# ---------------------------------------------------------------------------
+
+class TestFormatAge(unittest.TestCase):
+
+    def test_minutes_when_less_than_one_hour(self):
+        result = clauck._format_age(0.5)
+        self.assertEqual(result, "30m ago")
+
+    def test_zero_hours_is_zero_minutes(self):
+        result = clauck._format_age(0.0)
+        self.assertEqual(result, "0m ago")
+
+    def test_hours_when_one_to_twenty_three(self):
+        result = clauck._format_age(5.5)
+        self.assertEqual(result, "5.5h ago")
+
+    def test_exactly_one_hour(self):
+        result = clauck._format_age(1.0)
+        self.assertEqual(result, "1.0h ago")
+
+    def test_days_when_twenty_four_hours_or_more(self):
+        result = clauck._format_age(48.0)
+        self.assertEqual(result, "2.0d ago")
+
+    def test_days_fractional(self):
+        result = clauck._format_age(36.0)
+        self.assertEqual(result, "1.5d ago")
+
+    def test_just_under_one_hour_is_minutes(self):
+        result = clauck._format_age(0.999)
+        self.assertIn("m ago", result)
+        self.assertNotIn("h ago", result)
+
+    def test_just_under_twenty_four_hours_is_hours(self):
+        result = clauck._format_age(23.9)
+        self.assertIn("h ago", result)
+        self.assertNotIn("d ago", result)
+
+
+# ---------------------------------------------------------------------------
+# _tombstone_age_hours
+# ---------------------------------------------------------------------------
+
+class TestTombstoneAgeHours(unittest.TestCase):
+
+    def _stone_with_offset(self, hours_ago: float) -> dict:
+        ts = datetime.now(timezone.utc) - timedelta(hours=hours_ago)
+        return {"ts": ts.isoformat()}
+
+    def test_recent_tombstone_returns_small_age(self):
+        stone = self._stone_with_offset(1.0)
+        age = clauck._tombstone_age_hours(stone)
+        self.assertAlmostEqual(age, 1.0, delta=0.01)
+
+    def test_old_tombstone_returns_large_age(self):
+        stone = self._stone_with_offset(48.0)
+        age = clauck._tombstone_age_hours(stone)
+        self.assertAlmostEqual(age, 48.0, delta=0.1)
+
+    def test_missing_ts_returns_infinity(self):
+        stone = {}
+        age = clauck._tombstone_age_hours(stone)
+        self.assertEqual(age, float("inf"))
+
+    def test_malformed_ts_returns_infinity(self):
+        stone = {"ts": "not-a-timestamp"}
+        age = clauck._tombstone_age_hours(stone)
+        self.assertEqual(age, float("inf"))
+
+    def test_z_suffix_timestamp_parsed(self):
+        ts = datetime.now(timezone.utc) - timedelta(hours=2.0)
+        stone = {"ts": ts.strftime("%Y-%m-%dT%H:%M:%SZ")}
+        age = clauck._tombstone_age_hours(stone)
+        self.assertAlmostEqual(age, 2.0, delta=0.05)
+
+
+# ---------------------------------------------------------------------------
+# _list_tombstones and _find_tombstone
+# ---------------------------------------------------------------------------
+
+def _make_stone(tmpdir: Path, job: str, hours_ago: float = 1.0, **extra) -> dict:
+    """Write a tombstone JSON file and return the dict."""
+    ts = datetime.now(timezone.utc) - timedelta(hours=hours_ago)
+    stone = {"job": job, "ts": ts.isoformat(), "trip_reason": "max_budget", **extra}
+    # Filename format mirrors run-job.sh: <job>-<ts>.json
+    fname = f"{job}-{ts.strftime('%Y%m%dT%H%M%SZ')}.json"
+    (tmpdir / fname).write_text(json.dumps(stone))
+    return stone
+
+
+class TestListTombstones(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._broken_dir = Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _patch_broken_dir(self):
+        return patch.object(clauck, "BROKEN_DIR", self._broken_dir)
+
+    def test_empty_dir_returns_empty_list(self):
+        with self._patch_broken_dir():
+            result = clauck._list_tombstones()
+        self.assertEqual(result, [])
+
+    def test_missing_dir_returns_empty_list(self):
+        with patch.object(clauck, "BROKEN_DIR", Path(self._tmp.name) / "nonexistent"):
+            result = clauck._list_tombstones()
+        self.assertEqual(result, [])
+
+    def test_single_tombstone_returned(self):
+        _make_stone(self._broken_dir, "my-job")
+        with self._patch_broken_dir():
+            result = clauck._list_tombstones()
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["job"], "my-job")
+
+    def test_multiple_tombstones_all_returned(self):
+        _make_stone(self._broken_dir, "job-a", hours_ago=1.0)
+        _make_stone(self._broken_dir, "job-b", hours_ago=2.0)
+        with self._patch_broken_dir():
+            result = clauck._list_tombstones()
+        names = {s["job"] for s in result}
+        self.assertEqual(names, {"job-a", "job-b"})
+
+    def test_malformed_json_file_skipped(self):
+        (self._broken_dir / "bad-20260101T000000Z.json").write_text("not json {{{")
+        _make_stone(self._broken_dir, "good-job")
+        with self._patch_broken_dir():
+            result = clauck._list_tombstones()
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["job"], "good-job")
+
+    def test_tombstones_sorted_newest_first_same_job(self):
+        # Sorting is lexicographic by filename. For the same job prefix,
+        # timestamp ordering determines newest-first correctly.
+        _make_stone(self._broken_dir, "repeat-job", hours_ago=10.0, spend_usd=0.1)
+        _make_stone(self._broken_dir, "repeat-job", hours_ago=1.0, spend_usd=0.9)
+        with self._patch_broken_dir():
+            result = clauck._list_tombstones()
+        # Newest stone (spend=0.9) should appear before older stone (spend=0.1)
+        spends = [s["spend_usd"] for s in result]
+        self.assertGreater(spends.index(0.1), spends.index(0.9))
+
+
+class TestFindTombstone(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._broken_dir = Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _patch_broken_dir(self):
+        return patch.object(clauck, "BROKEN_DIR", self._broken_dir)
+
+    def test_returns_none_when_no_tombstones(self):
+        with self._patch_broken_dir():
+            result = clauck._find_tombstone("any-job")
+        self.assertIsNone(result)
+
+    def test_returns_none_when_job_not_present(self):
+        _make_stone(self._broken_dir, "other-job")
+        with self._patch_broken_dir():
+            result = clauck._find_tombstone("my-job")
+        self.assertIsNone(result)
+
+    def test_finds_exact_job(self):
+        _make_stone(self._broken_dir, "target-job")
+        with self._patch_broken_dir():
+            result = clauck._find_tombstone("target-job")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["job"], "target-job")
+
+    def test_does_not_match_partial_name(self):
+        _make_stone(self._broken_dir, "my-job-extended")
+        with self._patch_broken_dir():
+            result = clauck._find_tombstone("my-job")
+        self.assertIsNone(result)
+
+    def test_returns_most_recent_when_multiple(self):
+        _make_stone(self._broken_dir, "repeat-job", hours_ago=5.0, spend_usd=1.0)
+        _make_stone(self._broken_dir, "repeat-job", hours_ago=1.0, spend_usd=2.0)
+        with self._patch_broken_dir():
+            result = clauck._find_tombstone("repeat-job")
+        # Should return the more-recent one (hours_ago=1.0, spend_usd=2.0)
+        self.assertAlmostEqual(result["spend_usd"], 2.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_clauck_cron.py
+++ b/tests/test_clauck_cron.py
@@ -1,0 +1,206 @@
+"""Unit tests for cron-matching and next-fire helpers in lib/clauck.
+
+Covers: _cron_matches, _cron_next, _fmt_next_fire.
+
+These are a standalone copy of the scheduler's cron logic (kept separate so
+the clauck CLI has no runtime dependency on lib/scheduler.py). Testing them
+independently catches divergence from the scheduler implementation and
+regression-proofs the output of `clauck next`.
+
+Run: python3 -m pytest tests/test_clauck_cron.py
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+
+_CLAUCK_PATH = Path(__file__).parent.parent / "lib" / "clauck"
+_loader = importlib.machinery.SourceFileLoader("clauck", str(_CLAUCK_PATH))
+_spec = importlib.util.spec_from_loader("clauck", _loader)
+clauck = importlib.util.module_from_spec(_spec)
+_loader.exec_module(clauck)
+
+_cron_matches = clauck._cron_matches
+_cron_next = clauck._cron_next
+_fmt_next_fire = clauck._fmt_next_fire
+
+
+# ---------------------------------------------------------------------------
+# _cron_matches
+# ---------------------------------------------------------------------------
+
+class TestCronMatches(unittest.TestCase):
+    def _dt(self, y=2026, mo=4, d=1, h=0, m=0):
+        return datetime(y, mo, d, h, m)
+
+    def test_wildcard_matches_any_minute(self):
+        self.assertTrue(_cron_matches("* * * * *", self._dt(m=0)))
+        self.assertTrue(_cron_matches("* * * * *", self._dt(m=30)))
+        self.assertTrue(_cron_matches("* * * * *", self._dt(m=59)))
+
+    def test_exact_minute_match(self):
+        self.assertTrue(_cron_matches("30 * * * *", self._dt(m=30)))
+        self.assertFalse(_cron_matches("30 * * * *", self._dt(m=31)))
+
+    def test_exact_hour_match(self):
+        self.assertTrue(_cron_matches("0 9 * * *", self._dt(h=9, m=0)))
+        self.assertFalse(_cron_matches("0 9 * * *", self._dt(h=10, m=0)))
+
+    def test_step_expression(self):
+        # */15: fire at 0, 15, 30, 45
+        self.assertTrue(_cron_matches("*/15 * * * *", self._dt(m=0)))
+        self.assertTrue(_cron_matches("*/15 * * * *", self._dt(m=15)))
+        self.assertTrue(_cron_matches("*/15 * * * *", self._dt(m=30)))
+        self.assertTrue(_cron_matches("*/15 * * * *", self._dt(m=45)))
+        self.assertFalse(_cron_matches("*/15 * * * *", self._dt(m=1)))
+        self.assertFalse(_cron_matches("*/15 * * * *", self._dt(m=16)))
+
+    def test_range_expression(self):
+        # 1-5: fire Mon–Fri (dow 1–5 in cron = Mon–Fri)
+        # Wednesday = isoweekday 3 → cron dow 3
+        wednesday = self._dt(d=1)  # 2026-04-01 is a Wednesday
+        self.assertTrue(_cron_matches("0 9 * * 1-5", wednesday.replace(hour=9)))
+        # Sunday = isoweekday 7 → cron dow 0
+        sunday = self._dt(d=5)  # 2026-04-05 is a Sunday
+        self.assertFalse(_cron_matches("0 9 * * 1-5", sunday.replace(hour=9)))
+
+    def test_dom_and_month(self):
+        # First day of April
+        self.assertTrue(_cron_matches("0 0 1 4 *", self._dt(d=1, mo=4)))
+        self.assertFalse(_cron_matches("0 0 1 4 *", self._dt(d=2, mo=4)))
+        self.assertFalse(_cron_matches("0 0 1 4 *", self._dt(d=1, mo=5)))
+
+    def test_invalid_field_count_raises(self):
+        with self.assertRaises(ValueError):
+            _cron_matches("* * * *", self._dt())  # only 4 fields
+
+    def test_comma_list(self):
+        # Fire at minute 0, 30
+        self.assertTrue(_cron_matches("0,30 * * * *", self._dt(m=0)))
+        self.assertTrue(_cron_matches("0,30 * * * *", self._dt(m=30)))
+        self.assertFalse(_cron_matches("0,30 * * * *", self._dt(m=15)))
+
+
+# ---------------------------------------------------------------------------
+# _cron_next
+# ---------------------------------------------------------------------------
+
+class TestCronNext(unittest.TestCase):
+    def test_hourly_next_fire(self):
+        # "0 * * * *" — next should be on the next hour boundary
+        from_dt = datetime(2026, 4, 18, 15, 5)
+        nf = _cron_next("0 * * * *", from_dt)
+        self.assertIsNotNone(nf)
+        self.assertEqual(nf, datetime(2026, 4, 18, 16, 0))
+
+    def test_next_fire_is_strictly_after_from(self):
+        # from_dt already ON the boundary — next must be STRICTLY after
+        from_dt = datetime(2026, 4, 18, 16, 0)
+        nf = _cron_next("0 * * * *", from_dt)
+        self.assertIsNotNone(nf)
+        self.assertEqual(nf, datetime(2026, 4, 18, 17, 0))
+
+    def test_daily_job_next_day(self):
+        # "0 9 * * *" at 10:00 today → tomorrow 09:00
+        from_dt = datetime(2026, 4, 18, 10, 0)
+        nf = _cron_next("0 9 * * *", from_dt)
+        self.assertIsNotNone(nf)
+        self.assertEqual(nf, datetime(2026, 4, 19, 9, 0))
+
+    def test_daily_job_same_day(self):
+        # "0 9 * * *" at 08:59 today → 09:00 today
+        from_dt = datetime(2026, 4, 18, 8, 59)
+        nf = _cron_next("0 9 * * *", from_dt)
+        self.assertIsNotNone(nf)
+        self.assertEqual(nf, datetime(2026, 4, 18, 9, 0))
+
+    def test_unmatchable_cron_returns_none(self):
+        # 30th of February never exists — no match in 8 days
+        from_dt = datetime(2026, 4, 18, 0, 0)
+        nf = _cron_next("0 0 30 2 *", from_dt)
+        self.assertIsNone(nf)
+
+    def test_five_minute_interval(self):
+        from_dt = datetime(2026, 4, 18, 12, 3)
+        nf = _cron_next("*/5 * * * *", from_dt)
+        self.assertIsNotNone(nf)
+        self.assertEqual(nf, datetime(2026, 4, 18, 12, 5))
+
+    def test_invalid_cron_returns_none(self):
+        # Malformed expression: 4 fields only — _cron_matches raises ValueError,
+        # _cron_next catches it and returns None.
+        from_dt = datetime(2026, 4, 18, 0, 0)
+        nf = _cron_next("* * * *", from_dt)
+        self.assertIsNone(nf)
+
+
+# ---------------------------------------------------------------------------
+# _fmt_next_fire
+# ---------------------------------------------------------------------------
+
+class TestFmtNextFire(unittest.TestCase):
+    def _now(self):
+        return datetime(2026, 4, 18, 12, 0)
+
+    def test_minutes_format(self):
+        now = self._now()
+        nf = now + timedelta(minutes=30)
+        result = _fmt_next_fire(nf, now)
+        self.assertIn("30m", result)
+        self.assertIn("today", result)
+
+    def test_one_minute_minimum(self):
+        # Delta of 30 seconds → shows "in 1m" (minimum 1)
+        now = self._now()
+        nf = now + timedelta(seconds=30)
+        result = _fmt_next_fire(nf, now)
+        self.assertIn("1m", result)
+
+    def test_hours_format(self):
+        now = self._now()
+        nf = now + timedelta(hours=3, minutes=15)
+        result = _fmt_next_fire(nf, now)
+        self.assertIn("3h 15m", result)
+
+    def test_hours_exact_no_minutes(self):
+        now = self._now()
+        nf = now + timedelta(hours=2)
+        result = _fmt_next_fire(nf, now)
+        self.assertIn("2h", result)
+        self.assertNotIn("0m", result)
+
+    def test_days_format(self):
+        now = self._now()
+        nf = now + timedelta(days=2, hours=3)
+        result = _fmt_next_fire(nf, now)
+        self.assertIn("2d 3h", result)
+
+    def test_tomorrow_label(self):
+        now = self._now()
+        nf = now + timedelta(hours=14)  # tomorrow
+        result = _fmt_next_fire(nf, now)
+        self.assertIn("tomorrow", result)
+
+    def test_today_label(self):
+        now = self._now()
+        nf = now + timedelta(minutes=45)
+        result = _fmt_next_fire(nf, now)
+        self.assertIn("today", result)
+        self.assertIn(nf.strftime("%H:%M"), result)
+
+    def test_future_day_uses_weekday(self):
+        now = self._now()
+        nf = now + timedelta(days=3)
+        result = _fmt_next_fire(nf, now)
+        # Neither today nor tomorrow — should show abbreviated weekday name
+        self.assertNotIn("today", result)
+        self.assertNotIn("tomorrow", result)
+        self.assertIn(nf.strftime("%a"), result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Closes #113

## Motivation

`clauck next` relies on three pure helper functions — `_cron_matches`, `_cron_next`, and `_fmt_next_fire` — to show when each job will next fire. These are a standalone copy of the scheduler's cron logic, duplicated so the `clauck` CLI has no runtime dependency on `lib/scheduler.py`. Until now, they had no test coverage.

If `_cron_next` silently diverged from `scheduler.py`'s logic (e.g., an edge case in step syntax, leap-day boundary, or the DOW Sunday alias), `clauck next` would show wrong times with no test catching the regression.

## Before / After

**Before:** `python3 -m pytest tests/` runs 201 tests. `_cron_matches`, `_cron_next`, and `_fmt_next_fire` in `lib/clauck` are entirely dark.

**After:** 23 new tests in `tests/test_clauck_cron.py`. `python3 -m pytest tests/` runs 224 tests, all green.

## What's covered

**`_cron_matches` (8 tests):**
- Wildcard matches any minute
- Exact minute / hour match
- Step expression (*/15) — hits 0,15,30,45; misses 1,16
- Range expression (1-5 DOW) — weekday matches, weekend misses
- DOM+month precision
- Invalid field count raises ValueError
- Comma list (0,30)

**`_cron_next` (7 tests):**
- Hourly job: next fire is on next hour boundary
- Strictly after: when `from_dt` is already on a boundary, next is the FOLLOWING match
- Daily job crossing midnight
- Daily job same day (before the hour)
- Unmatchable pattern (Feb 30) returns None
- Five-minute interval
- Malformed cron (4 fields) returns None (ValueError caught internally)

**`_fmt_next_fire` (8 tests):**
- "in Xm" with today label
- One-minute minimum for sub-60s delta
- "in Xh Xm" compound
- "in Xh" with no trailing "0m"
- "in Xd Xh" multi-day
- "tomorrow HH:MM" label
- "today HH:MM" label with correct time
- Future day uses abbreviated weekday name (not today/tomorrow)

## Cost-to-Value

206-line test file. Zero production code changes. Zero new dependencies. CI adds ~0.1s.

## Confidence

- 23/23 pass locally
- Tests import `lib/clauck` via `SourceFileLoader` (same pattern as `test_clauck.py` / `test_dag_runner.py`)
- Pure functions: no filesystem, no mocking required

## Validation Steps

```bash
git fetch origin '#113-cron-helper-tests'
git checkout '#113-cron-helper-tests'
python3 -m pytest tests/test_clauck_cron.py -v
# expect: 23 passed
python3 -m pytest tests/ -v
# expect: 224 passed
```

## Dependency note

This PR is stacked on `#53-budget-breaker-revival` (PR #56). It can be merged independently of PR #56 once rebased onto main, as `tests/test_clauck_cron.py` only touches the `lib/clauck` cron helpers that exist on main.