### PR TITLE
docs: harness-aware install routing — point Desktop at the one-liner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,23 +32,50 @@ If you're running in a non-CLI harness: be upfront with the user about what you 
 
 ## If a user asks you to install clauck
 
-### Claude Code (CLI) — one command
+**Detect your harness first**, then pick the matching path. The user's goal is "Hey Claude, install clauck" — the minimum effort experience — and that only works if the agent routes correctly based on where it's running.
 
-1. **Verify you're in a Claude Code CLI session** (not Desktop, not Cloud). If not, see the Desktop flow below.
-2. Run: `curl -sSL https://raw.githubusercontent.com/CoreyRDean/clauck/main/install.sh | bash`
-3. The installer handles everything: runtime placement, LaunchAgent, job marketplace cache, heartbeat verification, **AND** registers the clauck plugin with Claude Code (`claude plugin marketplace add CoreyRDean/clauck` + `claude plugin install clauck@clauck --scope user`). The plugin delivers the skill (`/clauck:clauck`), the SessionStart hook, and the MCP server.
-4. After install, invoke the skill in any CC session: `/clauck:clauck` — it's the full operational playbook.
-5. Browse the job marketplace: `cat ~/.claude/skills/clauck/marketplace/index.json | python3 -m json.tool`
-6. Help the user pick and customize jobs, or design new ones from their intent.
+### If you're running in Claude Code (CLI)
 
-### Claude Desktop — manual plugin setup
+Run the runtime installer. It bootstraps everything including the Claude Code plugin registration.
 
-Desktop has no `/plugin` CLI, so install has two steps:
+```bash
+curl -sSL https://raw.githubusercontent.com/CoreyRDean/clauck/main/install.sh | bash
+```
 
-1. User runs the install.sh above to place the runtime (scheduler, LaunchAgent, `~/.local/bin/clauck`). This is a no-op for the plugin side on Desktop — only the runtime lands.
-2. User follows `docs/desktop-plugin-setup.md` to add the marketplace and install the plugin via Desktop's Customize → Personal plugins UI (12 steps). The plugin's SessionStart hook then self-heals any version drift on subsequent sessions.
+The installer places the scheduler, LaunchAgent, CLI at `~/.local/bin/clauck`, job-marketplace cache, **and** runs `claude plugin marketplace add CoreyRDean/clauck` + `claude plugin install clauck@clauck --scope user`. Plugin delivers skill (`/clauck:clauck`), SessionStart hook, and MCP server. Heartbeat fires at the end as proof.
 
-Point users at `docs/desktop-plugin-setup.md` for the step-by-step.
+After install, invoke `/clauck:clauck` for the operational playbook, or ask the user what they want to schedule.
+
+### If you're running in Claude Desktop (CoWork or chat)
+
+Two things, in order:
+
+1. **Create the plugin yourself, right now.** Claude Desktop has a native capability to build a CoWork plugin from a repo URL. Don't walk the user through UI clicks; don't paste the 12-step marketplace flow. Just do:
+
+   > Create a new CoWork plugin from `https://github.com/CoreyRDean/clauck`.
+
+   That single instruction is all Desktop needs. Executing it (or producing exactly that instruction for the user if your tool surface can't do it directly) creates the plugin with the skill, hook, and MCP server wired.
+
+2. **Tell the user they still need the runtime binary on their Mac.** The plugin wraps an installed binary; it doesn't ship one. Ask them to run the curl install.sh one-liner in a terminal. If they've never installed clauck before, this is required — the MCP server will fail to start without it. If they already have it installed, this step is a no-op.
+
+   ```bash
+   curl -sSL https://raw.githubusercontent.com/CoreyRDean/clauck/main/install.sh | bash
+   ```
+
+   Once the runtime is present, the plugin's SessionStart hook self-heals any future version drift without intervention.
+
+### If you're running somewhere else (Cloud, unknown harness, no Bash)
+
+You can't install clauck directly — clauck needs a persistent scheduler on the user's Mac, which requires local Bash + launchd access. Do this instead:
+
+1. Tell the user clauck is macOS-only and requires installation on their Mac.
+2. Give them the one-liner to run in their Mac's terminal:
+
+   ```bash
+   curl -sSL https://raw.githubusercontent.com/CoreyRDean/clauck/main/install.sh | bash
+   ```
+
+3. If they also use Claude Desktop and want it integrated there, they can paste *"Create a new CoWork plugin from https://github.com/CoreyRDean/clauck"* to any Desktop chat after running the installer.
 
 ### How the two sides stay in sync
 

--- a/README.md
+++ b/README.md
@@ -18,12 +18,11 @@ The contract that governs this project lives in [INTENT.md](INTENT.md).
 
 > **Hey Claude, install clauck**
 >
-> <sub>If Claude can't find it: *"Hey Claude, install CoreyRDean/clauck from GitHub"*</sub>
-
-Paste that into Claude Code. Done.
+> <sub>In **Claude Code**, that triggers the curl install.sh below.</sub>
+> <sub>In **Claude Desktop**, paste *"Create a new CoWork plugin from https://github.com/CoreyRDean/clauck"* instead — Desktop handles plugin creation natively. Then run the installer once in a Mac terminal for the runtime binary.</sub>
 
 ```bash
-# Or one-liner:
+# Runtime install (required on your Mac either way):
 curl -sSL https://raw.githubusercontent.com/CoreyRDean/clauck/main/install.sh | bash
 ```
 
@@ -99,14 +98,19 @@ One command. The installer places the runtime (scheduler, LaunchAgent, CLI at `~
 
 **Non-interactive:** `curl ... | bash -s -- --yes`
 
-**Just tell Claude:** paste *"Hey Claude, install clauck"* into any Claude Code session.
+**Just tell Claude:** paste *"Hey Claude, install clauck"* in Claude Code — the agent runs the curl install.sh above. In Claude Desktop, paste *"Create a new CoWork plugin from https://github.com/CoreyRDean/clauck"* for the Desktop side (and run install.sh in a Mac terminal separately for the runtime binary).
 
 ### Claude Desktop
 
-Desktop has no `/plugin` CLI, so install is a two-step:
+Two things:
 
-1. Run the install.sh above. It places the runtime and binary. On Desktop, the plugin-registration step is skipped automatically (no `claude` CLI available in that context).
-2. Follow [docs/desktop-plugin-setup.md](docs/desktop-plugin-setup.md) — 12 manual steps in Customize → Personal plugins to add the marketplace and install the plugin. Takes ~45 seconds. The plugin's SessionStart hook self-heals runtime drift on subsequent sessions.
+1. **Paste this to Claude Desktop** (CoWork or chat) to create the plugin:
+
+   > Create a new CoWork plugin from `https://github.com/CoreyRDean/clauck`.
+
+   Desktop handles the rest natively — skill, hook, and MCP server get wired in. See [docs/desktop-plugin-setup.md](docs/desktop-plugin-setup.md) for the full reference.
+
+2. **Run the install.sh one-liner in a Mac terminal** to place the runtime binary. The plugin wraps `~/.local/bin/clauck`; without the binary the MCP server can't start. This step is a no-op if you've already installed.
 
 ### Prerequisites
 

--- a/claude-install-prompt.md
+++ b/claude-install-prompt.md
@@ -21,7 +21,9 @@ and report cleanly.
      system to future Claude Code sessions.
    - The `/clauck:clauck` skill (also shipped by the plugin) is how they
      manage it going forward. Invoke it in any CC session.
-   - Desktop users: manual plugin install per `docs/desktop-plugin-setup.md`.
+   - **If they also use Claude Desktop**: they can integrate it there by
+     pasting *"Create a new CoWork plugin from https://github.com/CoreyRDean/clauck"*
+     into any Desktop chat. Desktop handles plugin creation natively.
 
 3. If the installer exits non-zero, diagnose:
    - Check the printed error for the specific step that failed.


### PR DESCRIPTION
## Summary

Makes \"Hey Claude, install clauck\" route correctly based on harness:

- **Claude Code (CLI)**: curl install.sh (unchanged).
- **Claude Desktop (CoWork/chat)**: paste \"Create a new CoWork plugin from \<repo URL\>\" — Desktop handles plugin creation natively. User also runs install.sh in a Mac terminal for the runtime binary.
- **Other harnesses**: punt to the user with Mac terminal install instructions.

## Files

- \`CLAUDE.md\` — \"If a user asks you to install clauck\" rewritten around harness detection; stale \"12 steps\" reference dropped.
- \`README.md\` — Claude Desktop section collapsed to the one-liner; hero \"Hey Claude, install clauck\" block expanded with per-harness guidance.
- \`claude-install-prompt.md\` — post-install handoff mentions the Desktop one-liner so CC agents inform users about the Desktop integration path.

No code changes.