### PR TITLE
fix: surface the CoWork plugin update prompt at every drift point

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,19 @@ You can't install clauck directly — clauck needs a persistent scheduler on the
 
 3. If they also use Claude Desktop and want it integrated there, they can paste *"Create a new CoWork plugin from https://github.com/CoreyRDean/clauck"* to any Desktop chat after running the installer.
 
+### CoWork plugin update prompt (keep this one-liner handy)
+
+When the user's clauck CLI (host Mac) version doesn't match the clauck plugin version inside CoWork, reconciliation is a paste:
+
+> Pull latest plugins/clauck/ from github.com/CoreyRDean/clauck and build a Cowork .plugin update.
+
+Two triggers for when to hand this to the user:
+
+1. **Plugin's SessionStart hook detects drift at CoWork load time** → the hook already prints the prompt into the agent's context with an explanation. Agent should surface it; user pastes it in the CoWork chat.
+2. **User just updated the CLI** (ran `install.sh` again) → `install.sh`'s success banner now prints the prompt too. If they're in a CoWork session after updating, they need to paste it to bring the plugin to match.
+
+Don't make users hunt for this string. If you detect CLI↔plugin drift in any context, print the one-liner verbatim so they can copy-paste.
+
 ### How the two sides stay in sync
 
 - Plugin and runtime versions are coupled via the same `VERSION` file in this repo, so release tags produce matched plugin+runtime versions.

--- a/docs/desktop-plugin-setup.md
+++ b/docs/desktop-plugin-setup.md
@@ -24,7 +24,19 @@ Done. Claude Desktop handles the rest natively.
 
 ## Updating
 
-Re-paste the one-liner — Claude Desktop rebuilds the plugin from the latest repo contents. Runtime reconciles on the next SessionStart (or re-run `install.sh` manually).
+Two sides. Update either — the plugin's SessionStart hook detects drift and prints a pointer to the other.
+
+**CoWork plugin side:**
+
+> Pull latest plugins/clauck/ from github.com/CoreyRDean/clauck and build a Cowork .plugin update.
+
+**Host Mac runtime side:** re-run `install.sh` in a Mac terminal:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/CoreyRDean/clauck/main/install.sh | bash
+```
+
+The installer prints the CoWork update prompt in its success banner so you can paste it directly into CoWork without looking it up.
 
 ## Uninstalling
 

--- a/install.sh
+++ b/install.sh
@@ -860,6 +860,16 @@ ${C_BOLD}Get started (through the clauck CLI):${C_RESET}
   ${C_BOLD}clauck uninstall${C_RESET}                     ${C_DIM}# preserves jobs, state, and logs${C_RESET}
   ${C_BOLD}clauck uninstall --wipe${C_RESET}              ${C_DIM}# also removes ~/.clauck${C_RESET}
 
+${C_BOLD}If you also use the clauck plugin in Claude Desktop / CoWork:${C_RESET}
+  The CLI you just installed may not match the plugin version CoWork has
+  cached. To bring the CoWork plugin up to date, paste this into a CoWork
+  chat:
+
+    ${C_BOLD}Pull latest plugins/clauck/ from github.com/CoreyRDean/clauck and build a Cowork .plugin update.${C_RESET}
+
+  (Skip this if you only use the CLI. Plugin and CLI versions are coupled;
+  running this keeps Desktop's plugin aligned with the CLI you just installed.)
+
 ${C_DIM}Full docs: the clauck plugin skill (invoke /clauck:clauck in any CC session)${C_RESET}
 ${C_DIM}Source:    https://github.com/CoreyRDean/clauck${C_RESET}
 

--- a/plugins/clauck/hooks/sessionstart.sh
+++ b/plugins/clauck/hooks/sessionstart.sh
@@ -89,10 +89,18 @@ mkdir -p "$(dirname "$INSTALL_LOG")" 2>/dev/null || true
 advise_runtime_missing() {
     local reason="$1"
     {
-        echo "clauck plugin: $reason"
-        echo "  Running in CoWork sandbox — can't install on the host from here."
-        echo "  Ask the user to run this on their Mac in a terminal:"
+        echo ""
+        echo "⚠ clauck plugin: $reason"
+        echo "  Running in CoWork sandbox — can't install the runtime on the host from here."
+        echo ""
+        echo "  The user should run this on their Mac in a terminal to install the runtime:"
+        echo ""
         echo "    curl -sSL https://raw.githubusercontent.com/CoreyRDean/clauck/main/install.sh | bash"
+        echo ""
+        echo "  After the runtime is installed, rebuild this CoWork plugin by pasting:"
+        echo ""
+        echo "    Pull latest plugins/clauck/ from github.com/CoreyRDean/clauck and build a Cowork .plugin update."
+        echo ""
     }
 }
 
@@ -177,12 +185,30 @@ if [ -n "$PLUGIN_VERSION" ] && [ -f "$VERSION_FILE" ]; then
        && should_heal_now; then
         date +%s > "$LAST_HEAL_FILE" 2>/dev/null || true
         if [ "$IN_COWORK_SANDBOX" = "1" ]; then
-            # Can't install from the sandbox — just print the advisory.
-            # The current binary still works for this session; the user
-            # can update on the host side at their convenience.
-            echo "clauck plugin: version drift (plugin=${PLUGIN_VERSION}, binary=${BINARY_VERSION_FULL})"
-            echo "  Running in CoWork sandbox; update on the host Mac:"
-            echo "    curl -sSL https://raw.githubusercontent.com/CoreyRDean/clauck/main/install.sh | bash"
+            # Can't install from the sandbox — instruct the agent how to
+            # reconcile. The host clauck binary is reachable via the
+            # mount; the plugin side is updated by re-running CoWork's
+            # plugin-creation flow from the latest repo contents. This
+            # output goes into the agent's context as part of the
+            # SessionStart hook, so an agent reading it will know what
+            # to do next without the user having to paste anything.
+            echo ""
+            echo "⚠ clauck plugin version drift (plugin=${PLUGIN_VERSION}, binary=${BINARY_VERSION_FULL})"
+            if [ "$BINARY_VERSION_SEMVER" \> "$PLUGIN_VERSION" ]; then
+                echo "  The host Mac's clauck CLI is newer than this plugin."
+                echo "  To update this CoWork plugin to match, the user should paste:"
+                echo ""
+                echo "    Pull latest plugins/clauck/ from github.com/CoreyRDean/clauck and build a Cowork .plugin update."
+                echo ""
+            else
+                echo "  This plugin is newer than the host Mac's clauck CLI."
+                echo "  To update the host CLI, the user should run in a Mac terminal:"
+                echo ""
+                echo "    curl -sSL https://raw.githubusercontent.com/CoreyRDean/clauck/main/install.sh | bash"
+                echo ""
+            fi
+            echo "  The current binary still works for this session."
+            echo ""
         else
             run_install_in_background "version drift: plugin=${PLUGIN_VERSION}, binary=${BINARY_VERSION_FULL}"
         fi


### PR DESCRIPTION
## Summary

User-reported bare-minimum CoWork update prompt:

> Pull latest plugins/clauck/ from github.com/CoreyRDean/clauck and build a Cowork .plugin update.

This one-liner now appears wherever drift is detected so users don't have to hunt for it.

## Changes

- **SessionStart hook** — drift branch in CoWork prints the exact prompt, selecting direction based on which side is newer. Missing-runtime advisory also includes both host-install and plugin-update prompts.
- **install.sh success banner** — every CLI install/update completion now prints the CoWork update prompt so users paste it straight from the banner if they use Desktop.
- **\`docs/desktop-plugin-setup.md\`** — \"Updating\" section updated to show both sides.
- **\`CLAUDE.md\`** — harness-aware install guidance gets a \"CoWork plugin update prompt\" section instructing agents to surface the one-liner verbatim on drift detection.

## .mcpb status

Confirmed removed from all production paths (installer, plugin, builder, docs, CI). Only remaining reference: \`uninstall.sh\` keeps \`\$HOME/.clauck/clauck.mcpb\` in the legacy-cleanup FILES list so users upgrading from the pre-plugin era get a clean uninstall. Appropriate.

## Test plan

- [x] \`bash -n\` clean on install.sh, uninstall.sh, sessionstart.sh, clauck-mcp-launcher
- [ ] After merge: simulate drift in CoWork, verify the hook's output contains the exact one-liner
- [ ] After merge: run install.sh on a Mac terminal, verify the banner prints the CoWork update prompt