### PR TITLE
Fix legacy auto-report config compatibility

### DIFF
--- a/lib/clauck
+++ b/lib/clauck
@@ -156,7 +156,7 @@ def jit_update_check() -> None:
 
 def _notify_pending_auto_reports() -> None:
     """Print a one-line notice if background agents have queued auto-draft reports."""
-    auto_report_mode = load_config().get("auto_report", {}).get("mode", "off")
+    auto_report_mode = _auto_report_mode()
     if auto_report_mode == "off" or not REPORTS_DIR.exists():
         return
     auto_drafts = list(REPORTS_DIR.glob("*-auto.json"))
@@ -184,6 +184,23 @@ def load_config() -> dict:
         except (OSError, ValueError):
             return {}
     return {}
+
+
+def _auto_report_mode(config: "dict | None" = None) -> str:
+    """Return the normalized auto-report mode.
+
+    Tolerates legacy scalar configs such as {"auto_report": "draft"} so old
+    persisted state cannot brick the CLI during startup or report handling.
+    """
+    cfg = config if isinstance(config, dict) else load_config()
+    raw = cfg.get("auto_report", {})
+    if isinstance(raw, str):
+        mode = raw.strip().lower()
+    elif isinstance(raw, dict):
+        mode = str(raw.get("mode", "off")).strip().lower()
+    else:
+        mode = "off"
+    return mode if mode in {"off", "draft", "auto"} else "off"
 
 
 def job_state(name: str) -> dict:
@@ -431,7 +448,7 @@ def cmd_status() -> None:
     print(f"  notifications: {'on' if notif else 'off'} (toggle: clauck config set notifications true/false)")
 
     # Check for pending auto-report drafts
-    auto_report_mode = config.get("auto_report", {}).get("mode", "off")
+    auto_report_mode = _auto_report_mode(config)
     print(f"  auto-report: {auto_report_mode}"
           f" (change: clauck config set auto_report.mode draft|auto|off)")
     if auto_report_mode != "off" and REPORTS_DIR.exists():
@@ -1524,7 +1541,11 @@ def cmd_config(args: list[str]) -> None:
     # Navigate to the nested key
     d = config
     for k in key_path[:-1]:
-        d = d.setdefault(k, {})
+        child = d.get(k)
+        if not isinstance(child, dict):
+            child = {}
+            d[k] = child
+        d = child
     d[key_path[-1]] = value
     CONFIG_FILE.write_text(json.dumps(config, indent=2) + "\n")
     print(f"  set {args[1]} = {value}")
@@ -3670,7 +3691,7 @@ def _write_auto_draft(
     """
     import time as _t
 
-    auto_report_mode = load_config().get("auto_report", {}).get("mode", "off")
+    auto_report_mode = _auto_report_mode()
     if auto_report_mode == "off":
         return None
 

--- a/tests/test_clauck_report.py
+++ b/tests/test_clauck_report.py
@@ -267,6 +267,9 @@ class TestWriteAutoDraft(unittest.TestCase):
     def _set_mode(self, mode: str) -> None:
         self.config_file.write_text(json.dumps({"auto_report": {"mode": mode}}))
 
+    def _set_scalar_mode(self, mode: str) -> None:
+        self.config_file.write_text(json.dumps({"auto_report": mode}))
+
     def test_off_mode_returns_none(self):
         self._set_mode("off")
         result = _write_auto_draft("test-agent", "title", "body")
@@ -295,6 +298,12 @@ class TestWriteAutoDraft(unittest.TestCase):
 
     def test_auto_mode_creates_file(self):
         self._set_mode("auto")
+        path = _write_auto_draft("doctor", "A bug", "body")
+        self.assertIsNotNone(path)
+        self.assertTrue(path.exists())
+
+    def test_scalar_draft_mode_creates_file(self):
+        self._set_scalar_mode("draft")
         path = _write_auto_draft("doctor", "A bug", "body")
         self.assertIsNotNone(path)
         self.assertTrue(path.exists())
@@ -369,6 +378,9 @@ class TestNotifyPendingAutoReports(unittest.TestCase):
     def _set_mode(self, mode: str) -> None:
         self.config_file.write_text(json.dumps({"auto_report": {"mode": mode}}))
 
+    def _set_scalar_mode(self, mode: str) -> None:
+        self.config_file.write_text(json.dumps({"auto_report": mode}))
+
     def _capture_notify(self):
         buf = io.StringIO()
         with patch("builtins.print", side_effect=lambda *a, **k: buf.write(" ".join(str(x) for x in a) + "\n")):
@@ -402,6 +414,14 @@ class TestNotifyPendingAutoReports(unittest.TestCase):
         self.assertIn("auto-report", out)
         self.assertIn("clauck report --inbox", out)
 
+    def test_scalar_draft_mode_prints_notice(self):
+        self._set_scalar_mode("draft")
+        self.reports.mkdir()
+        (self.reports / "20260418T120000Z-doctor-auto.json").write_text("{}")
+        out = self._capture_notify()
+        self.assertIn("auto-report", out)
+        self.assertIn("clauck report --inbox", out)
+
     def test_notice_includes_count(self):
         self._set_mode("draft")
         self.reports.mkdir()
@@ -409,3 +429,27 @@ class TestNotifyPendingAutoReports(unittest.TestCase):
             (self.reports / f"20260418T12000{i}Z-doctor-auto.json").write_text("{}")
         out = self._capture_notify()
         self.assertIn("3", out)
+
+
+# ---------------------------------------------------------------------------
+# cmd_config — nested-key recovery for legacy scalar auto_report config
+# ---------------------------------------------------------------------------
+
+
+class TestCmdConfigAutoReportRecovery(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.config_file = Path(self.tmp.name) / "config.json"
+        self._orig_config = _mod.CONFIG_FILE
+        _mod.CONFIG_FILE = self.config_file
+
+    def tearDown(self):
+        _mod.CONFIG_FILE = self._orig_config
+        self.tmp.cleanup()
+
+    def test_set_nested_auto_report_mode_replaces_scalar_parent(self):
+        self.config_file.write_text(json.dumps({"auto_report": "draft"}))
+        with patch("builtins.print"):
+            _mod.cmd_config(["set", "auto_report.mode", "off"])
+        saved = json.loads(self.config_file.read_text())
+        self.assertEqual(saved["auto_report"], {"mode": "off"})


### PR DESCRIPTION
## Non-technical summary

This change makes clauck tolerate older `auto_report` config shapes instead of crashing on startup or when writing/reporting auto-drafts. Users who previously persisted `"auto_report": "draft"` can keep using the CLI, and a normal `clauck config set auto_report.mode ...` command now repairs that state in place.

This matters now because the bad persisted shape can brick the whole CLI before the user reaches a recovery command. After this change, the runtime stays usable and self-heals when the nested mode key is written again.

## Technical summary

- Added a central `_auto_report_mode()` normalizer in [`lib/clauck`](/Users/coreyrdean/.codex/worktrees/cd75/clauck/lib/clauck) to accept both legacy scalar config values and the current mapping form.
- Switched `_notify_pending_auto_reports`, `cmd_status`, and `_write_auto_draft` to use the normalized mode instead of assuming `auto_report` is always a dict.
- Hardened `cmd_config set <dotted.key>` so non-dict intermediate values are replaced with dicts, which lets `clauck config set auto_report.mode off` recover a legacy scalar config instead of raising `TypeError`.
- Added regression tests covering scalar-mode auto-draft writes, scalar-mode pending-report notices, and nested-key recovery in [`tests/test_clauck_report.py`](/Users/coreyrdean/.codex/worktrees/cd75/clauck/tests/test_clauck_report.py).
- Validation: `python3 -m pytest tests -q` (272 passed).

Breaking changes: none.

## Additional notes

- Trade-off: unknown `auto_report` values now normalize to `off` rather than propagating arbitrary strings through runtime behavior.
- Intentionally deferred: the separate `doctor --dry` auto-draft-before-`execvp` path from issue #125. This PR keeps scope to the persisted-config compatibility failure mode only.
- This is a partial fix for issue #125 rather than a full closure of every concern raised there.