### PR TITLE
fix: harden history --days argument validation

### DIFF
--- a/lib/clauck
+++ b/lib/clauck
@@ -4421,7 +4421,12 @@ def main() -> None:
         if "--days" in rest:
             idx = rest.index("--days")
             if idx + 1 < len(rest):
-                h_days = int(rest[idx + 1])
+                try:
+                    h_days = int(rest[idx + 1])
+                except ValueError:
+                    die("--days requires an integer")
+            else:
+                die("--days requires an integer")
             rest = [r for i, r in enumerate(rest) if i != idx and i != idx + 1]
         rest = [r for r in rest if r != "--all"]
         if rest:

--- a/tests/test_clauck_history_cost.py
+++ b/tests/test_clauck_history_cost.py
@@ -34,6 +34,20 @@ def _make_log(directory: Path, name: str, ts: str, pid: str, content: str) -> Pa
     return log
 
 
+def _run_main(*args: str) -> tuple[int, str, str]:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with patch.object(sys, "argv", ["clauck", *args]), \
+         patch("sys.stdout", stdout), \
+         patch("sys.stderr", stderr):
+        try:
+            _mod.main()
+            code = 0
+        except SystemExit as exc:
+            code = exc.code if isinstance(exc.code, int) else 1
+    return code, stdout.getvalue(), stderr.getvalue()
+
+
 # ---------------------------------------------------------------------------
 # _parse_log_summary
 # ---------------------------------------------------------------------------
@@ -276,6 +290,33 @@ class TestCmdCost(unittest.TestCase):
         os.utime(log, (sixty_days_ago, sixty_days_ago))
         out = self._run(all_time=True)
         self.assertIn("old-job", out)
+
+
+# ---------------------------------------------------------------------------
+# CLI parsing for `history`
+# ---------------------------------------------------------------------------
+
+class TestHistoryCliParsing(unittest.TestCase):
+
+    def test_history_days_requires_value(self):
+        code, stdout, stderr = _run_main("history", "--days")
+        self.assertEqual(code, 1)
+        self.assertEqual(stdout, "")
+        self.assertIn("error: --days requires an integer", stderr)
+
+    def test_history_days_requires_integer(self):
+        code, stdout, stderr = _run_main("history", "--days", "abc")
+        self.assertEqual(code, 1)
+        self.assertEqual(stdout, "")
+        self.assertIn("error: --days requires an integer", stderr)
+
+    def test_history_days_valid_value_reaches_command(self):
+        with patch.object(_mod, "cmd_history") as mock_history:
+            code, stdout, stderr = _run_main("history", "--days", "7", "heartbeat")
+        self.assertEqual(code, 0)
+        self.assertEqual(stdout, "")
+        self.assertEqual(stderr, "")
+        mock_history.assert_called_once_with("heartbeat", 30, 7, False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Non-technical summary
`clauck history --days` now rejects missing or malformed values with a clear CLI error instead of silently ignoring the flag or crashing with a Python traceback. This matters now because `history` should behave like its sibling `cost` command and surface operator input mistakes immediately.

## Technical summary
- mirror `cmd_cost`'s `--days` guard in the `history` CLI parser so `--days` requires a following integer value
- add CLI-level regression coverage for three cases: missing value, non-integer value, and a valid integer that still reaches `cmd_history`
- keep the change scoped to argument validation only; no history rendering or log parsing behavior changed
- full verification: `python3 -m pytest tests/test_clauck_history_cost.py -q` and `python3 -m unittest discover tests`
- no breaking changes beyond turning previously-bad invocations into a clear non-zero error

## Additional notes
- This closes issue #122 without widening into the separate history/cost test-hardening work tracked in #126.
- The valid-path acceptance case is covered in the new parser test to confirm existing behavior remains intact.