### PR TITLE
Fix revive to honor job config and explicit session

### DIFF
--- a/lib/clauck
+++ b/lib/clauck
@@ -72,6 +72,8 @@ Examples:
 
 from __future__ import annotations
 
+import importlib.machinery
+import importlib.util
 import json
 import os
 import subprocess
@@ -184,6 +186,72 @@ def load_config() -> dict:
         except (OSError, ValueError):
             return {}
     return {}
+
+
+def _load_scheduler_module():
+    """Load scheduler.py from the dev tree or installed runtime, if present."""
+    candidates = (
+        Path(__file__).resolve().parent / "scheduler.py",
+        JOBS_DIR / "scheduler.py",
+    )
+    for scheduler_path in candidates:
+        if not scheduler_path.exists():
+            continue
+        loader = importlib.machinery.SourceFileLoader(
+            f"clauck_scheduler_{abs(hash(str(scheduler_path)))}",
+            str(scheduler_path),
+        )
+        spec = importlib.util.spec_from_loader(loader.name, loader)
+        if spec is None:
+            continue
+        module = importlib.util.module_from_spec(spec)
+        loader.exec_module(module)
+        return module
+    return None
+
+
+def _discover_job_config(name: str) -> dict | None:
+    """Return the scheduler-resolved config for a job name, if available."""
+    scheduler = _load_scheduler_module()
+    if scheduler is None:
+        return None
+    try:
+        for job in scheduler.discover_jobs():
+            if job.get("name") == name:
+                return job
+    except Exception:
+        return None
+    return None
+
+
+def _build_job_env(job: dict, trigger: str) -> dict[str, str]:
+    """Build the CLAUDE_JOB_* env block expected by run-job.sh."""
+    env = os.environ.copy()
+    env["CLAUDE_JOB_NAME"] = str(job["name"])
+    env["CLAUDE_JOB_PATH"] = str(job["path"])
+    env["CLAUDE_JOB_CWD"] = str(job["cwd"])
+    env["CLAUDE_JOB_MAX_TURNS"] = str(job["max_turns"])
+    env["CLAUDE_JOB_MAX_BUDGET_USD"] = str(job["max_budget_usd"])
+    env["CLAUDE_JOB_EFFORT"] = str(job["effort"])
+    env["CLAUDE_JOB_CRON"] = str(job.get("cron", ""))
+    env["CLAUDE_JOB_MODEL"] = str(job.get("model", ""))
+    ss = job.get("setting_sources")
+    if ss is not None:
+        env["CLAUDE_JOB_SETTING_SOURCES"] = str(ss)
+        env["CLAUDE_JOB_SETTING_SOURCES_SET"] = "1"
+    if job.get("strict_mcp_config"):
+        env["CLAUDE_JOB_STRICT_MCP_CONFIG"] = "1"
+    if job.get("debounce_seconds"):
+        env["CLAUDE_JOB_DEBOUNCE_SECONDS"] = str(job["debounce_seconds"])
+    if job.get("session_persist"):
+        env["CLAUDE_JOB_SESSION_PERSIST"] = "1"
+    if job.get("interactive"):
+        env["CLAUDE_JOB_INTERACTIVE"] = "1"
+    if job.get("trace_tool_calls"):
+        env["CLAUDE_JOB_TRACE_TOOL_CALLS"] = "1"
+    env["CLAUDE_JOB_TRIGGER"] = trigger
+    env["CLAUDE_JOB_FIRED_AT"] = datetime.now(timezone.utc).isoformat()
+    return env
 
 
 def job_state(name: str) -> dict:
@@ -1696,6 +1764,7 @@ def cmd_revive(name: str, budget: float | None = None, turns: int | None = None)
     orig_turns = stone.get("orig_max_turns", 50)
     trip_reason = stone.get("trip_reason", "?")
     spend = stone.get("spend_usd")
+    job_config = _discover_job_config(name)
 
     new_budget = budget if budget is not None else round(orig_budget * 2, 2)
     new_turns = turns if turns is not None else orig_turns * 2
@@ -1722,15 +1791,16 @@ def cmd_revive(name: str, budget: float | None = None, turns: int | None = None)
     # Fetch current consumers from the manifest so the revived job can chain them
     # (only used on the solo-revive fallback path; during DAG resume, dag-runner.py
     # handles consumer delivery as it completes remaining layers).
-    consumers: list[str] = []
-    try:
-        m = load_manifest()
-        for j in m.get("jobs", []):
-            if j.get("name") == name:
-                consumers = list(j.get("consumers", []))
-                break
-    except Exception:
-        pass
+    consumers = list(job_config.get("consumers", [])) if job_config else []
+    if not consumers:
+        try:
+            m = load_manifest()
+            for j in m.get("jobs", []):
+                if j.get("name") == name:
+                    consumers = list(j.get("consumers", []))
+                    break
+        except Exception:
+            pass
 
     spend_str = f"${spend:.4f}" if spend is not None else "unknown"
     print(f"  reviving '{name}' as background job (tripped: {trip_reason}, spent: {spend_str})")
@@ -1786,9 +1856,19 @@ def cmd_revive(name: str, budget: float | None = None, turns: int | None = None)
         # Solo revive: bypass scheduler.py --trigger (which would re-run producers
         # on pipeline nodes); run this single node non-interactively and let
         # run-job.sh chain directly-declared consumers on success.
+        env = (
+            _build_job_env(job_config, "revive")
+            if job_config is not None
+            else {
+                **os.environ,
+                "CLAUDE_JOB_NAME": name,
+                "CLAUDE_JOB_TRIGGER": "revive",
+                "CLAUDE_JOB_FIRED_AT": datetime.now(timezone.utc).isoformat(),
+            }
+        )
         subprocess.Popen(
             ["zsh", str(run_job), name],
-            env={**os.environ, "CLAUDE_JOB_TRIGGER": "revive"},
+            env=env,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,

--- a/lib/run-job.sh
+++ b/lib/run-job.sh
@@ -473,7 +473,7 @@ fi
 # On subsequent runs, we pass --resume <session_id> so claude has context
 # from all prior runs of this job.
 SESSION_ID_FILE="$STATE_DIR/${JOB_NAME}.session-id"
-if [ "${CLAUDE_JOB_SESSION_PERSIST:-}" = "1" ] && [ -f "$SESSION_ID_FILE" ]; then
+if [ -z "${REVIVE_SESSION_ID:-}" ] && [ "${CLAUDE_JOB_SESSION_PERSIST:-}" = "1" ] && [ -f "$SESSION_ID_FILE" ]; then
   STORED_SID="$(cat "$SESSION_ID_FILE" 2>/dev/null | tr -d '[:space:]')"
   if [ -n "$STORED_SID" ]; then
     CLAUDE_ARGS+=(--resume "$STORED_SID")
@@ -486,9 +486,10 @@ fi
 EXIT_CODE=$?
 
 # --- Stale session-ID retry: if --resume failed, retry without it ---
-# If exit was non-zero, session persistence was active, and the error looks
-# session-related, drop the stale session-id and retry once from scratch.
-if [ "$EXIT_CODE" -ne 0 ] && [ "${CLAUDE_JOB_SESSION_PERSIST:-}" = "1" ] && [ -f "$SESSION_ID_FILE" ]; then
+# If exit was non-zero, session persistence was active, the run was not an
+# explicit revive, and the error looks session-related, drop the stale
+# session-id and retry once from scratch.
+if [ "$EXIT_CODE" -ne 0 ] && [ -z "${REVIVE_SESSION_ID:-}" ] && [ "${CLAUDE_JOB_SESSION_PERSIST:-}" = "1" ] && [ -f "$SESSION_ID_FILE" ]; then
   # Check last ~40 lines of log for session/resume-related error text
   if tail -40 "$LOG_FILE" 2>/dev/null | grep -qi -e "session" -e "resume"; then
     echo "stage=session_retry stale_session_id=$(cat "$SESSION_ID_FILE" 2>/dev/null | tr -d '[:space:]')" >> "$LOG_FILE"

--- a/tests/test_clauck_revive.py
+++ b/tests/test_clauck_revive.py
@@ -1,0 +1,187 @@
+"""Tests for solo revive config resolution and explicit resume precedence.
+
+Run: python3 -m unittest tests.test_clauck_revive
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import io
+import json
+import os
+import stat
+import subprocess
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+
+_CLAUCK_PATH = Path(__file__).parent.parent / "lib" / "clauck"
+_loader = importlib.machinery.SourceFileLoader("clauck_revive", str(_CLAUCK_PATH))
+_spec = importlib.util.spec_from_loader("clauck_revive", _loader)
+clauck = importlib.util.module_from_spec(_spec)
+_loader.exec_module(clauck)
+
+_RUN_JOB = Path(__file__).parent.parent / "lib" / "run-job.sh"
+
+
+def _make_tombstone(directory: Path, job: str, **extra) -> None:
+    ts = datetime.now(timezone.utc) - timedelta(hours=1)
+    stone = {
+        "job": job,
+        "ts": ts.isoformat(),
+        "trip_reason": "max_budget",
+        "session_id": "revive-session-123",
+        "orig_max_budget_usd": 1.25,
+        "orig_max_turns": 22,
+        "spend_usd": 0.75,
+        **extra,
+    }
+    name = f"{job}-{ts.strftime('%Y%m%dT%H%M%SZ')}.json"
+    (directory / name).write_text(json.dumps(stone), encoding="utf-8")
+
+
+class TestCmdReviveSoloEnv(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.jobs_dir = self.root / "jobs"
+        self.jobs_dir.mkdir()
+        self.state_dir = self.root / "state"
+        self.state_dir.mkdir()
+        self.broken_dir = self.root / "broken"
+        self.broken_dir.mkdir()
+        self.run_job = self.jobs_dir / "run-job.sh"
+        self.run_job.write_text("#!/bin/zsh\nexit 0\n", encoding="utf-8")
+        self.run_job.chmod(self.run_job.stat().st_mode | stat.S_IXUSR)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_revive_uses_resolved_job_config_for_solo_path(self):
+        _make_tombstone(self.broken_dir, "logical-job")
+        job_config = {
+            "name": "logical-job",
+            "path": str(self.root / "custom" / "actual-job.md"),
+            "cwd": str(self.root / "workspace"),
+            "max_turns": 77,
+            "max_budget_usd": 3.5,
+            "effort": "medium",
+            "cron": "0 9 * * 1-5",
+            "model": "sonnet",
+            "setting_sources": "",
+            "strict_mcp_config": True,
+            "debounce_seconds": 120,
+            "session_persist": True,
+            "interactive": True,
+            "trace_tool_calls": True,
+            "consumers": ["downstream-a", "downstream-b"],
+        }
+        stdout = io.StringIO()
+        with patch.object(clauck, "JOBS_DIR", self.jobs_dir), \
+             patch.object(clauck, "STATE_DIR", self.state_dir), \
+             patch.object(clauck, "BROKEN_DIR", self.broken_dir), \
+             patch.object(clauck, "_discover_job_config", return_value=job_config), \
+             patch("sys.stdout", stdout), \
+             patch.object(clauck.subprocess, "Popen") as mock_popen:
+            clauck.cmd_revive("logical-job")
+
+        args, kwargs = mock_popen.call_args
+        self.assertEqual(args[0], ["zsh", str(self.run_job), "logical-job"])
+        env = kwargs["env"]
+        self.assertEqual(env["CLAUDE_JOB_NAME"], "logical-job")
+        self.assertEqual(env["CLAUDE_JOB_PATH"], job_config["path"])
+        self.assertEqual(env["CLAUDE_JOB_CWD"], job_config["cwd"])
+        self.assertEqual(env["CLAUDE_JOB_MAX_TURNS"], "77")
+        self.assertEqual(env["CLAUDE_JOB_MAX_BUDGET_USD"], "3.5")
+        self.assertEqual(env["CLAUDE_JOB_EFFORT"], "medium")
+        self.assertEqual(env["CLAUDE_JOB_MODEL"], "sonnet")
+        self.assertEqual(env["CLAUDE_JOB_CRON"], "0 9 * * 1-5")
+        self.assertEqual(env["CLAUDE_JOB_SETTING_SOURCES"], "")
+        self.assertEqual(env["CLAUDE_JOB_SETTING_SOURCES_SET"], "1")
+        self.assertEqual(env["CLAUDE_JOB_STRICT_MCP_CONFIG"], "1")
+        self.assertEqual(env["CLAUDE_JOB_DEBOUNCE_SECONDS"], "120")
+        self.assertEqual(env["CLAUDE_JOB_SESSION_PERSIST"], "1")
+        self.assertEqual(env["CLAUDE_JOB_INTERACTIVE"], "1")
+        self.assertEqual(env["CLAUDE_JOB_TRACE_TOOL_CALLS"], "1")
+        self.assertEqual(env["CLAUDE_JOB_TRIGGER"], "revive")
+        self.assertIn("CLAUDE_JOB_FIRED_AT", env)
+
+        revive_payload = json.loads((self.state_dir / "logical-job.revive.json").read_text())
+        self.assertEqual(revive_payload["session_id"], "revive-session-123")
+        self.assertEqual(revive_payload["max_budget_usd"], 2.5)
+        self.assertEqual(revive_payload["max_turns"], 44)
+        self.assertEqual(revive_payload["consumers"], ["downstream-a", "downstream-b"])
+        self.assertEqual(list(self.broken_dir.glob("logical-job-*.json")), [])
+        self.assertIn("tail logs with: clauck logs logical-job --show", stdout.getvalue())
+
+
+class TestRunJobResumePrecedence(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.home = Path(self.tmp.name)
+        self.jobs_dir = self.home / ".clauck"
+        self.state_dir = self.jobs_dir / ".state"
+        self.jobs_dir.mkdir()
+        self.state_dir.mkdir()
+        (self.home / ".local" / "bin").mkdir(parents=True)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_explicit_revive_session_skips_persisted_resume(self):
+        fake_claude = self.home / ".local" / "bin" / "claude"
+        fake_claude.write_text(
+            "#!/bin/zsh\n"
+            "printf '%s\\n' \"$@\" > \"$HOME/claude-args.txt\"\n"
+            "printf '{\"session_id\":\"new-session\",\"terminal_reason\":\"completed\",\"total_cost_usd\":0.01}\\n'\n",
+            encoding="utf-8",
+        )
+        fake_claude.chmod(fake_claude.stat().st_mode | stat.S_IXUSR)
+
+        (self.jobs_dir / "prompt.md").write_text("global prompt\n", encoding="utf-8")
+        (self.jobs_dir / "my-job.md").write_text(
+            "---\n"
+            "session_persist: true\n"
+            "---\n"
+            "Do the thing.\n",
+            encoding="utf-8",
+        )
+        (self.state_dir / "my-job.revive.json").write_text(
+            json.dumps({
+                "session_id": "revive-session",
+                "max_budget_usd": 9.0,
+                "max_turns": 88,
+                "consumers": [],
+            }),
+            encoding="utf-8",
+        )
+        (self.state_dir / "my-job.session-id").write_text("persisted-session\n", encoding="utf-8")
+
+        env = os.environ.copy()
+        env["HOME"] = str(self.home)
+        env["CLAUDE_JOB_SESSION_PERSIST"] = "1"
+
+        result = subprocess.run(
+            ["/bin/zsh", str(_RUN_JOB), "my-job"],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+        args = (self.home / "claude-args.txt").read_text(encoding="utf-8").splitlines()
+        self.assertEqual(args.count("--resume"), 1)
+        resume_index = args.index("--resume")
+        self.assertEqual(args[resume_index + 1], "revive-session")
+        self.assertNotIn("persisted-session", args)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Non-technical summary
- `clauck revive` now resumes the intended job configuration instead of falling back to default runtime settings.
- This matters because revived jobs with custom `cwd`, model/budget settings, or `name:` values different from their filename could fail or resume the wrong session.
- After this change, revive behaves much closer to a normal fire: it uses the job's real resolved config and respects the explicit tombstone session the user asked to continue.

## Technical summary
- Fixes the solo-revive path in `lib/clauck` to load the scheduler-resolved job config and rebuild the full `CLAUDE_JOB_*` env block before launching `run-job.sh`.
- Keeps direct consumer chaining on revive, using the resolved job config first and the smaller manifest as a fallback.
- Updates `lib/run-job.sh` so an explicit revive session suppresses the session-persistence `--resume` append and the stale-session retry path.
- Adds `tests/test_clauck_revive.py` to cover both the CLI env injection and the shell-level single-`--resume` behavior.
- Verified with `python3 -m unittest discover tests`, `bash -n lib/run-job.sh`, and `python3 -c "import ast; ast.parse(open('lib/clauck').read())"`.

Relevant intent: this strengthens the stable job/frontmatter contract and backward-compatible revive behavior expected by `INTENT.md`, especially for configured jobs that should not silently fall back to defaults.

No breaking changes.

## Additional notes
- Trade-off: `cmd_revive` now consults scheduler discovery to recover the live resolved job config instead of relying only on the user-facing manifest, because the manifest no longer carries enough execution detail for a correct revive.
- Intentionally deferred: broader command-level coverage for `cmd_broken` / `cmd_discard` and DAG-specific revive integration beyond this explicit session/config fix.
- Remaining gap: revive now honors the intended solo-job config and session, but the wider tombstone command surface still has room for more integration-style coverage.