### PR TITLE
Fix semantic hangs after terminal JSON

### DIFF
--- a/lib/clauck
+++ b/lib/clauck
@@ -2660,12 +2660,7 @@ def _parse_interpreter_result(
     routing: dict = {}
     interpreter_error = ""
 
-    envelope: dict = {}
-    if result.stdout and result.stdout.strip():
-        try:
-            envelope = json.loads(result.stdout)
-        except (json.JSONDecodeError, ValueError):
-            pass
+    envelope = _extract_json_envelope(result.stdout)
 
     if result.returncode == 0 and envelope:
         inner = envelope.get("result", "").strip()
@@ -2698,6 +2693,98 @@ def _parse_interpreter_result(
         interpreter_error = "interpreter produced no output"
 
     return routing, interpreter_error
+
+
+def _extract_json_envelope(text: str | None) -> dict:
+    """Return the most relevant JSON envelope from Claude stdout text."""
+    if not text or not text.strip():
+        return {}
+    stripped = text.strip()
+    try:
+        parsed = json.loads(stripped)
+        if isinstance(parsed, dict):
+            return parsed
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    for line in reversed(stripped.splitlines()):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            parsed = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+    return {}
+
+
+def _run_json_cli(
+    argv: list[str],
+    *,
+    terminal_wait_seconds: float = 5.0,
+    kill_wait_seconds: float = 5.0,
+) -> "subprocess.CompletedProcess[str]":
+    """Run a JSON-emitting CLI without hanging forever after terminal output."""
+    import threading
+
+    proc = subprocess.Popen(
+        argv,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+    stdout_parts: list[str] = []
+    stderr_parts: list[str] = []
+    terminal_seen = threading.Event()
+
+    def _drain_stdout() -> None:
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            stdout_parts.append(line)
+            if _extract_json_envelope(line):
+                terminal_seen.set()
+        proc.stdout.close()
+
+    def _drain_stderr() -> None:
+        assert proc.stderr is not None
+        for line in proc.stderr:
+            stderr_parts.append(line)
+        proc.stderr.close()
+
+    out_thread = threading.Thread(target=_drain_stdout, daemon=True)
+    err_thread = threading.Thread(target=_drain_stderr, daemon=True)
+    out_thread.start()
+    err_thread.start()
+
+    try:
+        while proc.poll() is None:
+            if terminal_seen.wait(timeout=0.1):
+                break
+
+        if terminal_seen.is_set() and proc.poll() is None:
+            try:
+                proc.wait(timeout=terminal_wait_seconds)
+            except subprocess.TimeoutExpired:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=kill_wait_seconds)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=kill_wait_seconds)
+        returncode = proc.wait()
+    finally:
+        out_thread.join(timeout=1.0)
+        err_thread.join(timeout=1.0)
+
+    return subprocess.CompletedProcess(
+        argv,
+        returncode,
+        "".join(stdout_parts),
+        "".join(stderr_parts),
+    )
 
 
 def _log_interpreter_failure(
@@ -4192,7 +4279,7 @@ def cmd_semantic(text: str) -> None:
         # Use Sonnet for reliability — Haiku was generating explanatory prose
         # instead of strict JSON on edge cases. Cost increase is marginal
         # (~$0.03-0.05 vs $0.01) and the reliability is worth it.
-        result_s1 = subprocess.run(
+        result_s1 = _run_json_cli(
             [claude_bin, "-p", user_prompt,
              "--append-system-prompt", interpreter_prompt,
              "--model", "sonnet",
@@ -4202,7 +4289,6 @@ def cmd_semantic(text: str) -> None:
              "--setting-sources", "",
              "--strict-mcp-config",
              "--mcp-config", str(empty_mcp)],
-            capture_output=True, text=True,
         )
     except Exception:
         spinner_running[0] = False
@@ -4334,7 +4420,7 @@ def cmd_semantic(text: str) -> None:
     })
 
     try:
-        result = subprocess.run(
+        result = _run_json_cli(
             [claude_bin, "-p", enhanced_prompt,
              "--append-system-prompt", system_prompt,
              "--dangerously-skip-permissions",
@@ -4346,17 +4432,13 @@ def cmd_semantic(text: str) -> None:
              "--effort", exec_effort,
              "--output-format", "json",
              "--setting-sources", ""],
-            capture_output=True, text=True,
         )
     finally:
         spinner_running[0] = False
         spin_thread.join(timeout=0.5)
 
     # Parse Claude's JSON envelope
-    try:
-        envelope = json.loads(result.stdout) if result.stdout else {}
-    except (json.JSONDecodeError, ValueError):
-        envelope = {}
+    envelope = _extract_json_envelope(result.stdout)
 
     is_error = envelope.get("is_error", result.returncode != 0)
     claude_result = envelope.get("result", "").strip()

--- a/tests/test_clauck_semantic.py
+++ b/tests/test_clauck_semantic.py
@@ -1,0 +1,85 @@
+"""Unit tests for semantic JSON watchdog helpers in lib/clauck.
+
+Run: python3 -m unittest discover tests
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import json
+import re
+import subprocess
+import sys
+import time
+import unittest
+from pathlib import Path
+
+_LIB = Path(__file__).parent.parent / "lib" / "clauck"
+_loader = importlib.machinery.SourceFileLoader("clauck_semantic", str(_LIB))
+_mod = _loader.load_module()
+
+
+class TestExtractJsonEnvelope(unittest.TestCase):
+
+    def test_whole_stdout_json_is_parsed(self):
+        envelope = {"result": "done", "is_error": False}
+        parsed = _mod._extract_json_envelope(json.dumps(envelope))
+        self.assertEqual(parsed, envelope)
+
+    def test_last_json_line_wins_when_stdout_has_prefix_noise(self):
+        envelope = {"result": '{"command_type":"semantic"}', "is_error": False}
+        parsed = _mod._extract_json_envelope(f"note before json\n{json.dumps(envelope)}\n")
+        self.assertEqual(parsed, envelope)
+
+
+class TestParseInterpreterResult(unittest.TestCase):
+
+    def test_multiline_stdout_still_routes(self):
+        envelope = {"result": '{"command_type":"semantic","interpretation":"ok"}'}
+        result = subprocess.CompletedProcess(
+            ["claude"],
+            0,
+            f"cache warmup\n{json.dumps(envelope)}\n",
+            "",
+        )
+        routing, err = _mod._parse_interpreter_result(result, re)
+        self.assertEqual(err, "")
+        self.assertEqual(routing["command_type"], "semantic")
+        self.assertEqual(routing["interpretation"], "ok")
+
+
+class TestRunJsonCli(unittest.TestCase):
+
+    def test_clean_exit_preserves_json_stdout(self):
+        script = (
+            "import json; "
+            "print(json.dumps({'result':'ok','is_error':False}), flush=True)"
+        )
+        result = _mod._run_json_cli(
+            [sys.executable, "-c", script],
+            terminal_wait_seconds=0.1,
+            kill_wait_seconds=0.1,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(_mod._extract_json_envelope(result.stdout).get("result"), "ok")
+
+    def test_terminal_output_unblocks_lingering_process(self):
+        script = (
+            "import json,time; "
+            "print(json.dumps({'result':'ok','is_error':False}), flush=True); "
+            "time.sleep(30)"
+        )
+        started = time.monotonic()
+        result = _mod._run_json_cli(
+            [sys.executable, "-c", script],
+            terminal_wait_seconds=0.1,
+            kill_wait_seconds=0.1,
+        )
+        elapsed = time.monotonic() - started
+        self.assertLess(elapsed, 2.0)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(_mod._extract_json_envelope(result.stdout).get("result"), "ok")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Non-technical summary
- Semantic `clauck work` commands now stop waiting once Claude has already emitted its terminal JSON result.
- This matters because completed work could previously look hung forever, leaving the spinner running with no user-facing signal that execution was actually done.
- After this change, semantic commands surface the finished result promptly and only force-stop the child when it lingers after completion.

## Technical summary
- Added `_run_json_cli()` to stream stdout/stderr from JSON-mode Claude invocations, detect the first terminal JSON envelope, and escalate from `wait()` to `terminate()`/`kill()` if the child stays alive past a short grace window.
- Added `_extract_json_envelope()` so semantic parsing can recover the relevant Claude envelope even when stdout contains extra non-JSON lines.
- Switched both semantic stage-1 intent mining and stage-2 execution in `lib/clauck` to use the watchdog helper instead of `subprocess.run(..., capture_output=True)`.
- Added `tests/test_clauck_semantic.py` covering clean exits, lingering post-result processes, and interpreter parsing from mixed stdout.
- Validation: `python3 -m unittest tests.test_clauck_semantic tests.test_clauck_history_cost tests.test_clauck_report`, `python3 -m py_compile lib/clauck`, and `python3 -m unittest discover tests`.

Breaking changes: none.

## Additional notes
- Trade-off: this fix is intentionally scoped to the semantic/work path; it does not yet retrofit the separate doctor Claude-wrapper path.
- Intentionally deferred: `_work`-specific log files and broader observability changes proposed in issue #136.
- Remaining gap: if a Claude subprocess wedges before emitting any JSON at all, this change will not detect that earlier stall mode; it specifically fixes the completed-but-still-open pipe case from issue #136.