### PR TITLE
Align semantic routing with shared complexity sizing

### DIFF
--- a/INTENT.md
+++ b/INTENT.md
@@ -1,6 +1,6 @@
 # INTENT
 
-**Version:** v2
+**Version:** v3
 **Status:** Adopted
 **Scope:** Binds the `CoreyRDean/clauck` upstream repository. Revised only by PR amending this file.
 
@@ -91,7 +91,7 @@ Every job carries traceable provenance — a `source:` block tracking where the 
 
 Non-negotiable #4 says cost is a first-class surface. This property specifies *how*. Every Claude session clauck runs — doctor invocations, scheduled jobs (flat, module-anchor, module-stage), marketplace-installed jobs — derives its sizing (`model`, `effort`, `max_turns`, `max_budget_usd`) from a single shared formula keyed on a declared **complexity scale**, not from ad-hoc guessing at each site. The formula is visible in one file (`lib/sizing.py`), configurable per-user (`~/.clauck/.clauck.config.json` under `doctor`), introspectable by humans and agents (`clauck size <scale>`, `clauck inspect <job>`), and self-correcting (doctor bumps `scale_skew` on budget truncation, decays on clean runs). Clamps are visibly surfaced, not silent. A feature that does its own sizing math outside this pipeline, hides cost from the user, or sets a budget the user cannot audit violates this property. Parallel cost/sizing logic anywhere else in the codebase is a red flag — either the formula is wrong (fix the formula) or the feature shouldn't exist.
 
-**Scope of compliance at v2 adoption**: doctor, scheduler, CLI surfaces (`clauck size`, `clauck validate`, `clauck inspect`), and all marketplace jobs are fully compliant. The natural-language semantic interpreter (`clauck <anything>`, `clauck work <text>`) still emits its own stage-2 execution params directly — a known compliance gap tracked for follow-up. Job-creation guidance inside the semantic path already directs Claude to emit `complexity:` in any new job frontmatter, so the gap is only at the interpreter's own stage-2 sizing, not in the jobs it creates. This does not retroactively reshape the property — the claim above stands for all sites named in it — but the semantic path must be migrated before v3.
+**Scope of compliance at v3 adoption**: doctor, scheduler, CLI surfaces (`clauck size`, `clauck validate`, `clauck inspect`), marketplace jobs, and the natural-language semantic interpreter (`clauck <anything>`, `clauck work <text>`) all derive stage-2 execution parameters from the shared complexity-scale formula in `lib/sizing.py`. Job-creation guidance inside the semantic path continues to direct new jobs toward `complexity:` in frontmatter, so both scheduled execution and natural-language dispatch now speak the same cost contract.
 
 ---
 

--- a/lib/clauck
+++ b/lib/clauck
@@ -3492,15 +3492,9 @@ def _find_claude() -> str | None:
 def _build_interpreter_prompt() -> str:
     """Build the stage-1 interpreter system prompt with live manifest data.
 
-    KNOWN COMPLIANCE GAP vs INTENT.md §4 (Cost transparency, v2): the
-    semantic interpreter still emits exec_model/exec_effort/exec_max_turns/
-    exec_max_budget_usd directly in its routing JSON, rather than a
-    task_complexity_scale that Python derives from. The doctor interpreter
-    was migrated to the scale-only contract in this release; the semantic
-    path is tracked for migration before v3 of the INTENT contract. The
-    job-creation guidance inside this prompt already directs created jobs
-    to use `complexity:` in frontmatter, so the gap is only the
-    interpreter's OWN stage-2 sizing, not the jobs it creates.
+    Emits only task_complexity_scale for semantic routes. Python derives
+    model/effort/turns/budget from lib/sizing.py so cost math stays in one
+    audited place instead of being reimplemented in prompt text.
     """
     subcommands = (
         "list, status, fire, pause, resume, edit, logs, marketplace, install, "
@@ -3557,35 +3551,17 @@ def _build_interpreter_prompt() -> str:
 
 # Sizing the semantic execution (for command_type="semantic")
 
-Reason from the specific request, not from tiers. Every invocation has a different shape.
+Emit ONLY `task_complexity_scale` (float 0.0-1.0) for semantic routes. Do NOT emit model, effort, max_turns, or budget fields. Python derives those from `lib/sizing.py`.
 
-**Cost anchors** (approximate):
-- haiku: $1/M input, $5/M output, fast. Good for status queries, lookups, pure-reasoning tasks with small context.
-- sonnet: $3/M input, $15/M output. Good for anything that requires synthesis, code authoring, multi-file work.
-- opus: $15/M input, $75/M output. Reach for this only when deep reasoning across tangled code or architecture is unavoidable.
-- Tool-chain turn with tool calls + reasoning overhead: ~$0.02 on haiku, ~$0.08 on sonnet, ~$0.40 on opus.
+Choose the smallest honest scale that fits the request:
+- **0.10** — trivial state check, one quick lookup, list/filter.
+- **0.25** — focused single-surface task or one small job edit.
+- **0.40** — routine multi-source synthesis or moderate job creation/editing.
+- **0.55** — investigation across logs/state/config or multi-file reasoning.
+- **0.75** — DAG/module work, cross-subsystem audit, careful multi-step changes.
+- **0.95** — deep architectural reasoning or unusually tangled debugging.
 
-**Sizing dimensions:**
-- Read cost: how many files must the session open? How large are they? Manifest is ~1KB; a single job .md is ~3–6KB; a log can be hundreds of KB.
-- Write cost: how much new code/config will the session produce? 50 lines is small; 500 lines of new job scaffolding is not.
-- Reasoning depth: can the agent answer after one read, or must it synthesize across multiple files? Multi-step reasoning needs sonnet.
-- Verification: does the request include "make sure it works" or "test it"? Add turns for re-reading and validating.
-
-**Model selection heuristics (not rules):**
-- Status query, single lookup, list-and-filter → haiku is usually enough.
-- Create/modify a single job, answer a code question from context → sonnet.
-- Multi-file refactor, DAG wiring, module creation with internal stages, anything requiring careful cross-referencing → sonnet at high effort.
-- Genuinely architectural decisions or tricky debugging with many unknowns → opus, sparingly.
-
-**Turns and budget:**
-- Turns = roughly (reads + writes + verifications) × 1.3 for reasoning overhead.
-- Budget = sum of per-turn cost estimates × 1.3 for headroom. Hitting the budget ceiling truncates output; one that runs a few cents over is fine.
-- A session that lands at 60% of its budget ceiling did it right. 100% is too tight.
-
-**Hard floors and ceilings** (guardrails, not targets):
-- Minimum: 3 turns, $0.05, haiku.
-- Maximum: 60 turns, $3.00, sonnet (or opus if genuinely warranted).
-- Above the ceiling, reconsider the request — suggest breaking into multiple invocations in the interpretation field.
+Interpolate between anchors. Base the scale on read cost, write cost, reasoning depth, and verification load. The execution agent may still run on a larger model if MCP context makes haiku unsafe; your job is only to estimate task complexity honestly.
 
 # When the execution will CREATE or EDIT a job file — use `complexity:` in the frontmatter
 
@@ -3647,7 +3623,7 @@ For deterministic:
 Single-string `deterministic_cmd` is still accepted for simple cases (`"clauck list"`, `"clauck fire jobA"`), parsed with shell-style quoting. Prefer `deterministic_argv` by default — it cannot be misparsed.
 
 For semantic:
-{{"command_type": "semantic", "interpretation": "<distilled CLI directive>", "enhanced_prompt": "<prescriptive task brief>", "exec_model": "haiku"|"sonnet"|"opus", "exec_effort": "low"|"medium"|"high", "exec_max_turns": <int>, "exec_max_budget_usd": <float>}}"""
+{{"command_type": "semantic", "interpretation": "<distilled CLI directive>", "enhanced_prompt": "<prescriptive task brief>", "task_complexity_scale": <float 0.0-1.0>}}"""
 
 
 SEMANTIC_EXEC_SYSTEM_PROMPT = """You are the clauck CLI executing a user's natural-language command.
@@ -4386,10 +4362,7 @@ def cmd_semantic(text: str) -> None:
             "command_type": "semantic",
             "interpretation": "(interpreter failed — raw request passed through)",
             "enhanced_prompt": text,
-            "exec_model": "sonnet",
-            "exec_effort": "medium",
-            "exec_max_turns": 15,
-            "exec_max_budget_usd": 0.50,
+            "task_complexity_scale": 0.40,
         }
 
     interpretation = routing.get("interpretation", text)
@@ -4452,18 +4425,32 @@ def cmd_semantic(text: str) -> None:
             die(f"could not parse deterministic command: argv={argv!r} cmd={routing.get('deterministic_cmd', '')!r}")
         return
 
-    # semantic path — run execution pass with interpreter-chosen parameters
+    # semantic path — derive execution parameters from the shared sizing formula
     # Temporarily pause spinner to print interpretation, then resume with new label
     spinner_running[0] = False
     spin_thread.join(timeout=0.5)
     print(f"  \u2192 {interpretation}")
-    print(f"  {'─' * 60}")
-
-    exec_model = routing.get("exec_model", "sonnet")
-    exec_effort = routing.get("exec_effort", "medium")
-    exec_max_turns = str(routing.get("exec_max_turns", 15))
-    exec_max_budget = str(routing.get("exec_max_budget_usd", 0.50))
     enhanced_prompt = routing.get("enhanced_prompt", text)
+    semantic_cfg = sizing.load_doctor_config()
+    raw_scale = routing.get("task_complexity_scale")
+    if raw_scale is None:
+        raw_scale = routing.get("scale")
+    try:
+        scale = float(raw_scale) if raw_scale is not None else 0.40
+    except (TypeError, ValueError):
+        scale = 0.40
+    sized = sizing.compute_sizing(
+        scale,
+        sizing.estimate_tokens(enhanced_prompt or ""),
+        semantic_cfg,
+        strict_mcp=False,
+    )
+    exec_model = sized["model"]
+    exec_effort = sized["effort"]
+    exec_max_turns = str(sized["max_turns"])
+    exec_max_budget = str(sized["max_budget_usd"])
+    print(f"  \u2192 {sized['explanation']}")
+    print(f"  {'─' * 60}")
 
     system_prompt = SEMANTIC_EXEC_SYSTEM_PROMPT.replace("{JOBS_DIR}", str(JOBS_DIR))
     system_prompt = system_prompt.replace("{MANIFEST}", str(MANIFEST))

--- a/tests/test_clauck_history_cost.py
+++ b/tests/test_clauck_history_cost.py
@@ -225,9 +225,11 @@ class TestCmdCost(unittest.TestCase):
         self.assertGreater(cheap_pos, expensive_pos, "expensive job should appear before cheap job")
 
     def test_total_row_present_for_multiple_jobs(self):
+        now = datetime.now(timezone.utc)
         for i, cost in enumerate(["0.0100", "0.0200"]):
+            ts = (now - timedelta(days=i)).strftime("%Y%m%dT%H%M%SZ")
             self._log(
-                f"job-{i}", f"2026041{i}T170000Z", str(i + 1),
+                f"job-{i}", ts, str(i + 1),
                 f'{{"total_cost_usd":{cost}}}\n{{"terminal_reason":"completed"}}\n--- exit_code=0 ---\n',
             )
         out = self._run()

--- a/tests/test_clauck_semantic.py
+++ b/tests/test_clauck_semantic.py
@@ -6,13 +6,17 @@ Run: python3 -m unittest discover tests
 from __future__ import annotations
 
 import importlib.machinery
+import io
 import json
 import re
 import subprocess
 import sys
+import tempfile
 import time
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
+from unittest.mock import patch
 
 _LIB = Path(__file__).parent.parent / "lib" / "clauck"
 _loader = importlib.machinery.SourceFileLoader("clauck_semantic", str(_LIB))
@@ -48,6 +52,15 @@ class TestParseInterpreterResult(unittest.TestCase):
         self.assertEqual(routing["interpretation"], "ok")
 
 
+class TestBuildInterpreterPrompt(unittest.TestCase):
+
+    def test_semantic_routes_emit_scale_only(self):
+        prompt = _mod._build_interpreter_prompt()
+        self.assertIn('"task_complexity_scale"', prompt)
+        self.assertNotIn('"exec_model"', prompt)
+        self.assertIn("Emit ONLY `task_complexity_scale`", prompt)
+
+
 class TestRunJsonCli(unittest.TestCase):
 
     def test_clean_exit_preserves_json_stdout(self):
@@ -79,6 +92,80 @@ class TestRunJsonCli(unittest.TestCase):
         self.assertLess(elapsed, 2.0)
         self.assertNotEqual(result.returncode, 0)
         self.assertEqual(_mod._extract_json_envelope(result.stdout).get("result"), "ok")
+
+
+class TestCmdSemanticSizing(unittest.TestCase):
+
+    def test_semantic_stage_two_uses_shared_sizing_formula(self):
+        interpreter_routing = {
+            "command_type": "semantic",
+            "interpretation": "Inspect registered jobs",
+            "enhanced_prompt": "Read the manifest and summarize the registered jobs.",
+            "task_complexity_scale": 0.25,
+            # Legacy fields should be ignored once sizing is formula-derived.
+            "exec_model": "opus",
+            "exec_effort": "high",
+            "exec_max_turns": 99,
+            "exec_max_budget_usd": 9.99,
+        }
+        stage1 = subprocess.CompletedProcess(
+            ["claude"],
+            0,
+            json.dumps({"result": json.dumps(interpreter_routing), "is_error": False}),
+            "",
+        )
+        stage2 = subprocess.CompletedProcess(
+            ["claude"],
+            0,
+            json.dumps({"result": "done", "is_error": False}),
+            "",
+        )
+        sized = {
+            "model": "sonnet",
+            "effort": "medium",
+            "max_turns": 7,
+            "max_budget_usd": 0.42,
+            "explanation": "scale=0.25 -> sonnet/medium",
+        }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            state_dir = root / ".state"
+            jobs_dir = root / "jobs"
+            state_dir.mkdir(parents=True, exist_ok=True)
+            jobs_dir.mkdir(parents=True, exist_ok=True)
+
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with (
+                patch.object(_mod, "STATE_DIR", state_dir),
+                patch.object(_mod, "JOBS_DIR", jobs_dir),
+                patch.object(_mod, "MANIFEST", jobs_dir / ".manifest.json"),
+                patch.object(_mod, "CONFIG_FILE", jobs_dir / ".clauck.config.json"),
+                patch.object(_mod, "MARKETPLACE_DIR", root / "marketplace"),
+                patch.object(_mod, "TRIGGER_SCRIPT", root / "trigger-job.sh"),
+                patch.object(_mod, "_find_claude", return_value="/usr/bin/claude"),
+                patch.object(_mod, "_run_json_cli", side_effect=[stage1, stage2]) as mock_run_json_cli,
+                patch.object(_mod.sizing, "load_doctor_config", return_value={}),
+                patch.object(_mod.sizing, "compute_sizing", return_value=sized) as mock_compute_sizing,
+                redirect_stdout(stdout),
+                redirect_stderr(stderr),
+            ):
+                _mod.cmd_semantic("list my jobs")
+
+        mock_compute_sizing.assert_called_once_with(
+            0.25,
+            _mod.sizing.estimate_tokens("Read the manifest and summarize the registered jobs."),
+            {},
+            strict_mcp=False,
+        )
+        stage2_argv = mock_run_json_cli.call_args_list[1].args[0]
+        self.assertIn("--model", stage2_argv)
+        self.assertEqual(stage2_argv[stage2_argv.index("--model") + 1], "sonnet")
+        self.assertEqual(stage2_argv[stage2_argv.index("--effort") + 1], "medium")
+        self.assertEqual(stage2_argv[stage2_argv.index("--max-turns") + 1], "7")
+        self.assertEqual(stage2_argv[stage2_argv.index("--max-budget-usd") + 1], "0.42")
+        self.assertIn("scale=0.25 -> sonnet/medium", stdout.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Non-technical summary
This closes the remaining cost-transparency gap in clauck’s natural-language path. `clauck <anything>` and `clauck work <text>` now size their execution the same way scheduled jobs and doctor already do, so the runtime has one cost contract instead of a prompt-authored special case.

This matters now because the semantic interpreter was the last place still guessing model, effort, turns, and budget inside stage-1 prompt output. Moving that logic back into Python makes the behavior auditable, keeps sizing consistent across the runtime, and removes a known divergence called out in `INTENT.md`.

After this change, semantic routing estimates task complexity once, the runtime derives execution settings centrally, and the user sees the derived sizing explanation before stage 2 runs.

## Technical summary
- Changed `_build_interpreter_prompt()` so semantic routes emit `task_complexity_scale` instead of `exec_model` / `exec_effort` / `exec_max_turns` / `exec_max_budget_usd`.
- Updated `cmd_semantic()` to derive model, effort, turns, and budget through `lib/sizing.py`, including MCP-aware promotion behavior via `compute_sizing(..., strict_mcp=False)`.
- Added semantic regression coverage proving stage 2 ignores legacy exec fields and uses the shared sizing result instead.
- Updated `INTENT.md` to remove the documented compliance gap and mark the cost-transparency surface as fully aligned for the semantic interpreter.
- Stabilized one existing `cmd_cost` test by making its fixture timestamps relative to the current date; this was needed to keep the full suite green once the hardcoded April dates aged past the 30-day default window.

Breaking changes: none intended. The stage-1 semantic JSON contract changes internally from explicit exec fields to `task_complexity_scale`, but the external user-facing CLI behavior remains the same aside from now showing the derived sizing explanation.

## Additional notes
Trade-off: the interpreter prompt now does less direct sizing math, which is intentional. The classifier only estimates complexity; Python owns the execution arithmetic.

Deferred follow-up: none required for this increment, though any future semantic-routing tweaks should continue to treat `lib/sizing.py` as the only source of truth.

Remaining gap versus fuller vision: natural-language routing is now on the same sizing contract as the rest of the runtime, but broader semantic UX questions remain separate from this alignment change.
