### PR TITLE
Prevent issue watcher overwrites across colliding repo slugs

### DIFF
--- a/lib/clauck
+++ b/lib/clauck
@@ -3738,6 +3738,7 @@ After each check, write current state to `~/.clauck/.state/<job-name>.json`:
 
 def _install_issue_watcher(issue_url: str, notify_channel: str = "") -> str:
     """Install a watcher job for a GitHub issue. Returns the job name."""
+    import hashlib
     import re as _re
 
     m = _re.search(r"github\.com/([^/]+/[^/]+)/issues/(\d+)", issue_url)
@@ -3747,7 +3748,8 @@ def _install_issue_watcher(issue_url: str, notify_channel: str = "") -> str:
     number = m.group(2)
 
     slug = _re.sub(r"[^a-z0-9]+", "-", repo.lower()).strip("-")
-    job_name = f"gh-watch-{slug}-{number}"
+    repo_hash = hashlib.sha1(repo.lower().encode("utf-8")).hexdigest()[:8]
+    job_name = f"gh-watch-{slug}-{number}-{repo_hash}"
     job_path = JOBS_DIR / f"{job_name}.md"
 
     notify_default = notify_channel or ""

--- a/tests/test_clauck_report.py
+++ b/tests/test_clauck_report.py
@@ -182,12 +182,30 @@ class TestInstallIssueWatcher(unittest.TestCase):
         name = _install_issue_watcher(url)
         self.assertIn("99", name)
 
+    def test_same_repo_keeps_stable_name(self):
+        url = "https://github.com/acme/widget/issues/42"
+        self.assertEqual(_install_issue_watcher(url), _install_issue_watcher(url))
+
     def test_job_file_contains_issue_url(self):
         url = "https://github.com/acme/widget/issues/7"
         name = _install_issue_watcher(url)
         job = Path(self.tmp.name) / f"{name}.md"
         content = job.read_text()
         self.assertIn(url, content)
+
+    def test_repo_hash_prevents_dash_slash_collision(self):
+        left = _install_issue_watcher("https://github.com/acme/x-y/issues/42")
+        right = _install_issue_watcher("https://github.com/acme-x/y/issues/42")
+        self.assertNotEqual(left, right)
+        self.assertTrue((Path(self.tmp.name) / f"{left}.md").exists())
+        self.assertTrue((Path(self.tmp.name) / f"{right}.md").exists())
+
+    def test_repo_hash_prevents_dot_collision(self):
+        left = _install_issue_watcher("https://github.com/acme/re.po/issues/42")
+        right = _install_issue_watcher("https://github.com/acme-re/po/issues/42")
+        self.assertNotEqual(left, right)
+        self.assertTrue((Path(self.tmp.name) / f"{left}.md").exists())
+        self.assertTrue((Path(self.tmp.name) / f"{right}.md").exists())
 
     def test_job_file_has_valid_cron(self):
         url = "https://github.com/acme/widget/issues/7"


### PR DESCRIPTION
## Non-technical summary
New GitHub issue watcher installs no longer overwrite each other when two different repositories collapse to the same normalized slug. This matters now because the watcher flow is meant to be reusable across repos, and silent collisions break that promise by replacing one user-visible Cycle with another.

## Technical summary
- append a short stable hash of the full `owner/repo` identity when generating new watcher job names in `lib/clauck`
- keep the existing readable slug and issue number so installed watcher files are still recognizable in `~/.clauck`
- add regression coverage for the specific dash/slash and dot/slash collision shapes from issue #120
- add a stability test proving the same repo + issue still produces the same watcher name on repeated installs
- preserve existing installed watchers by limiting the change to new watcher creation only

Relevant intent:
- advances the inspectable, file-backed runtime contract in [`INTENT.md`](https://github.com/CoreyRDean/clauck/blob/main/INTENT.md) by ensuring repository identity is preserved in durable watcher artifacts instead of being lost to lossy normalization
- fixes open issue #120 without broadening the watcher surface or changing runtime semantics outside watcher creation

Tests:
- `python3 -m unittest tests.test_clauck_report`
- `python3 -m unittest discover tests`

Breaking changes:
- none for existing installs; new watcher job filenames gain a hash suffix to prevent cross-repo collisions

## Additional notes
Trade-offs:
- watcher names are slightly longer, but the suffix buys collision-proof identity without needing a migration for already-installed jobs

Deferred follow-up:
- existing previously-installed colliding watcher files are not auto-migrated in this change

Remaining gap:
- this fixes watcher creation for future installs; any pre-existing overwritten watcher would still need to be recreated manually if a user already hit the bug

Closes #120.