### PR TITLE
Align contributor test guidance with stdlib unittest

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,15 +47,19 @@ The installer uses the local `lib/`, `jobs/`, and `skill/` directories when it d
 
 1. Fork the repo and create a feature branch from `main`.
 2. Make your changes. Run the installer from your checkout to verify.
-3. If you touched `scheduler.py`, run the parser + evaluator tests:
+3. Run the unit suite:
+   ```bash
+   /usr/bin/python3 -m unittest discover tests -v
+   ```
+4. If you touched `scheduler.py`, run the parser + evaluator tests:
    ```bash
    /usr/bin/python3 -c "import ast; ast.parse(open('lib/scheduler.py').read())" && echo OK
    ```
-4. If you touched `install.sh` or `uninstall.sh`, syntax-check:
+5. If you touched `install.sh` or `uninstall.sh`, syntax-check:
    ```bash
    bash -n install.sh && bash -n uninstall.sh && echo OK
    ```
-5. Open a PR against `main`. Describe what changed and why.
+6. Open a PR against `main`. Describe what changed and why.
 
 ### PR checklist
 

--- a/tests/test_clauck.py
+++ b/tests/test_clauck.py
@@ -2,7 +2,7 @@
 
 Covers: _format_age, _tombstone_age_hours, _list_tombstones, _find_tombstone.
 
-Run: python3 -m pytest tests/test_clauck.py
+Run: python3 -m unittest tests.test_clauck
 """
 
 from __future__ import annotations

--- a/tests/test_clauck_cron.py
+++ b/tests/test_clauck_cron.py
@@ -7,7 +7,7 @@ the clauck CLI has no runtime dependency on lib/scheduler.py). Testing them
 independently catches divergence from the scheduler implementation and
 regression-proofs the output of `clauck next`.
 
-Run: python3 -m pytest tests/test_clauck_cron.py
+Run: python3 -m unittest tests.test_clauck_cron
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Non-technical summary
This tightens the contributor path around test execution so the instructions match what clauck actually supports in a clean checkout. Right now two test modules tell contributors to use `pytest`, but the repo and CI both rely on the Python standard library `unittest` runner instead.

This matters now because a fresh environment can successfully validate the repo without installing extra tooling, but the stale guidance sends contributors down a failing path first.

## Technical summary
- Updated the module-level `Run:` guidance in `tests/test_clauck.py` to use `python3 -m unittest tests.test_clauck`
- Updated the module-level `Run:` guidance in `tests/test_clauck_cron.py` to use `python3 -m unittest tests.test_clauck_cron`
- Added the full unit-suite command to `CONTRIBUTING.md` so the documented validation path matches CI and the repository's minimal-dependency contract
- Preserved the existing scheduler-specific and shell syntax verification guidance
- No breaking changes

## Validation
- Ran `/usr/bin/python3 -m unittest discover tests -v`

## Additional notes
Trade-off: this is intentionally scoped to the misleading invocation surfaces rather than broad contributor-doc cleanup.

Deferred follow-up: none required inside this slice; broader documentation rework would be a separate increment if needed.

Remaining gap to fuller vision: the repo still relies on scattered inline `Run:` hints across tests, so future drift is still possible unless that guidance is centralized later.