### PR TITLE
Cover broken job command paths with integration tests

### DIFF
--- a/tests/test_clauck.py
+++ b/tests/test_clauck.py
@@ -1,6 +1,7 @@
-"""Unit tests for budget circuit-breaker tombstone helpers in lib/clauck.
+"""Unit tests for circuit-breaker tombstone helpers and commands in lib/clauck.
 
-Covers: _format_age, _tombstone_age_hours, _list_tombstones, _find_tombstone.
+Covers: _format_age, _tombstone_age_hours, _list_tombstones, _find_tombstone,
+cmd_broken, and cmd_discard.
 
 Run: python3 -m unittest tests.test_clauck
 """
@@ -8,6 +9,7 @@ Run: python3 -m unittest tests.test_clauck
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 import os
 import sys
@@ -219,6 +221,86 @@ class TestFindTombstone(unittest.TestCase):
             result = clauck._find_tombstone("repeat-job")
         # Should return the more-recent one (hours_ago=1.0, spend_usd=2.0)
         self.assertAlmostEqual(result["spend_usd"], 2.0)
+
+
+class TestCmdBroken(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._broken_dir = Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _patch_broken_dir(self):
+        return patch.object(clauck, "BROKEN_DIR", self._broken_dir)
+
+    def test_prints_empty_state_when_no_tombstones(self):
+        stdout = io.StringIO()
+        with self._patch_broken_dir(), patch("sys.stdout", stdout):
+            clauck.cmd_broken()
+        self.assertEqual(stdout.getvalue().strip(), "no broken jobs")
+
+    def test_lists_sorted_tombstones_and_marks_stale_entries(self):
+        _make_stone(
+            self._broken_dir,
+            "repeat-job",
+            hours_ago=clauck.BROKEN_RETENTION_HOURS + 2,
+            spend_usd=1.25,
+            session_id="stale-session-1234567890",
+        )
+        _make_stone(
+            self._broken_dir,
+            "repeat-job",
+            hours_ago=1.0,
+            spend_usd=0.75,
+            session_id="fresh-session-1234567890",
+        )
+
+        stdout = io.StringIO()
+        with self._patch_broken_dir(), patch("sys.stdout", stdout):
+            clauck.cmd_broken()
+
+        out = stdout.getvalue()
+        self.assertIn("job", out)
+        self.assertIn("reason", out)
+        self.assertIn("revive: clauck revive <name>", out)
+        self.assertIn("discard: clauck discard <name>", out)
+        self.assertIn("repeat-job", out)
+        self.assertIn("[stale]", out)
+        self.assertLess(out.index("fresh-session-1234567890"), out.index("stale-session-1234567890"))
+
+
+class TestCmdDiscard(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._broken_dir = Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _patch_broken_dir(self):
+        return patch.object(clauck, "BROKEN_DIR", self._broken_dir)
+
+    def test_removes_all_matching_tombstones_and_reports_count(self):
+        _make_stone(self._broken_dir, "repeat-job", hours_ago=5.0)
+        _make_stone(self._broken_dir, "repeat-job", hours_ago=1.0)
+        _make_stone(self._broken_dir, "other-job", hours_ago=1.0)
+
+        stdout = io.StringIO()
+        with self._patch_broken_dir(), patch("sys.stdout", stdout):
+            clauck.cmd_discard("repeat-job")
+
+        self.assertEqual(list(self._broken_dir.glob("repeat-job-*.json")), [])
+        self.assertEqual(len(list(self._broken_dir.glob("other-job-*.json"))), 1)
+        self.assertIn("discarded 2 tombstone(s) for: repeat-job", stdout.getvalue())
+
+    def test_reports_missing_tombstone_without_error(self):
+        stdout = io.StringIO()
+        with self._patch_broken_dir(), patch("sys.stdout", stdout):
+            clauck.cmd_discard("missing-job")
+        self.assertIn("no tombstone found for: missing-job", stdout.getvalue())
 
 
 if __name__ == "__main__":

--- a/tests/test_clauck_revive.py
+++ b/tests/test_clauck_revive.py
@@ -1,4 +1,4 @@
-"""Tests for solo revive config resolution and explicit resume precedence.
+"""Tests for revive command flows and explicit resume precedence.
 
 Run: python3 -m unittest tests.test_clauck_revive
 """
@@ -118,6 +118,117 @@ class TestCmdReviveSoloEnv(unittest.TestCase):
         self.assertEqual(revive_payload["consumers"], ["downstream-a", "downstream-b"])
         self.assertEqual(list(self.broken_dir.glob("logical-job-*.json")), [])
         self.assertIn("tail logs with: clauck logs logical-job --show", stdout.getvalue())
+
+
+class TestCmdReviveDagResume(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.jobs_dir = self.root / "jobs"
+        self.jobs_dir.mkdir()
+        self.state_dir = self.root / "state"
+        self.state_dir.mkdir()
+        self.broken_dir = self.root / "broken"
+        self.broken_dir.mkdir()
+        self.run_job = self.jobs_dir / "run-job.sh"
+        self.run_job.write_text("#!/bin/zsh\nexit 0\n", encoding="utf-8")
+        self.run_job.chmod(self.run_job.stat().st_mode | stat.S_IXUSR)
+        self.dag_runner = self.jobs_dir / "dag-runner.py"
+        self.dag_runner.write_text("#!/usr/bin/python3\n", encoding="utf-8")
+        self.dag_state_dir = self.state_dir / ".dag-invocations"
+        self.dag_state_dir.mkdir()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_revive_uses_dag_runner_when_fresh_invocation_state_exists(self):
+        _make_tombstone(
+            self.broken_dir,
+            "logical-job",
+            dag_invocation_id="dag-123",
+            dag_root="root-job",
+        )
+        (self.dag_state_dir / "dag-123.json").write_text("{}", encoding="utf-8")
+        job_config = {"name": "logical-job", "consumers": ["downstream-a"]}
+        stdout = io.StringIO()
+
+        with patch.object(clauck, "JOBS_DIR", self.jobs_dir), \
+             patch.object(clauck, "STATE_DIR", self.state_dir), \
+             patch.object(clauck, "BROKEN_DIR", self.broken_dir), \
+             patch.object(clauck, "_discover_job_config", return_value=job_config), \
+             patch("sys.stdout", stdout), \
+             patch.object(clauck.subprocess, "Popen") as mock_popen:
+            clauck.cmd_revive("logical-job")
+
+        args, kwargs = mock_popen.call_args
+        self.assertEqual(
+            args[0],
+            ["/usr/bin/python3", str(self.dag_runner), "--resume", "dag-123"],
+        )
+        self.assertEqual(kwargs["env"]["CLAUDE_JOB_TRIGGER"], "revive-dag")
+
+        revive_payload = json.loads((self.state_dir / "logical-job.revive.json").read_text())
+        self.assertEqual(revive_payload["session_id"], "revive-session-123")
+        self.assertEqual(revive_payload["consumers"], [])
+        self.assertEqual(list(self.broken_dir.glob("logical-job-*.json")), [])
+        self.assertIn("tail dag log with: clauck logs root-job --follow", stdout.getvalue())
+
+
+class TestCmdReviveErrors(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.jobs_dir = self.root / "jobs"
+        self.jobs_dir.mkdir()
+        self.state_dir = self.root / "state"
+        self.state_dir.mkdir()
+        self.broken_dir = self.root / "broken"
+        self.broken_dir.mkdir()
+        self.run_job = self.jobs_dir / "run-job.sh"
+        self.run_job.write_text("#!/bin/zsh\nexit 0\n", encoding="utf-8")
+        self.run_job.chmod(self.run_job.stat().st_mode | stat.S_IXUSR)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_missing_tombstone_exits_with_helpful_error(self):
+        stderr = io.StringIO()
+        with patch.object(clauck, "BROKEN_DIR", self.broken_dir), \
+             patch("sys.stderr", stderr):
+            with self.assertRaises(SystemExit) as exc:
+                clauck.cmd_revive("missing-job")
+        self.assertEqual(exc.exception.code, 1)
+        self.assertIn("no broken tombstone found for: missing-job", stderr.getvalue())
+
+    def test_stale_tombstone_exits_before_revive(self):
+        _make_tombstone(
+            self.broken_dir,
+            "logical-job",
+            ts=(datetime.now(timezone.utc) - timedelta(hours=clauck.BROKEN_RETENTION_HOURS + 1)).isoformat(),
+        )
+        stderr = io.StringIO()
+        with patch.object(clauck, "JOBS_DIR", self.jobs_dir), \
+             patch.object(clauck, "STATE_DIR", self.state_dir), \
+             patch.object(clauck, "BROKEN_DIR", self.broken_dir), \
+             patch("sys.stderr", stderr):
+            with self.assertRaises(SystemExit) as exc:
+                clauck.cmd_revive("logical-job")
+        self.assertEqual(exc.exception.code, 1)
+        self.assertIn("session may no longer be resumable", stderr.getvalue())
+
+    def test_missing_session_id_exits_before_subprocess_spawn(self):
+        _make_tombstone(self.broken_dir, "logical-job", session_id="")
+        stderr = io.StringIO()
+        with patch.object(clauck, "JOBS_DIR", self.jobs_dir), \
+             patch.object(clauck, "STATE_DIR", self.state_dir), \
+             patch.object(clauck, "BROKEN_DIR", self.broken_dir), \
+             patch("sys.stderr", stderr):
+            with self.assertRaises(SystemExit) as exc:
+                clauck.cmd_revive("logical-job")
+        self.assertEqual(exc.exception.code, 1)
+        self.assertIn("has no session_id", stderr.getvalue())
 
 
 class TestRunJobResumePrecedence(unittest.TestCase):


### PR DESCRIPTION
## Non-technical summary
This closes the remaining test gap around clauck's broken-job recovery commands. `clauck broken`, `clauck revive`, and `clauck discard` now have direct command-level coverage, so future changes to the tombstone flow are less likely to regress silently.

Why this matters now: issue #124 is still open on `main`, and the repo has already needed follow-up fixes in these revive paths. The helper-level tests were no longer enough proof for the user-facing command surface.

The system is better afterward because the recovery flow now has a stronger safety net across happy paths, DAG resume behavior, and operator-facing failures.

## Technical summary
- Expanded [`tests/test_clauck.py`](https://github.com/CoreyRDean/clauck/blob/refactor/tombstone-command-coverage/tests/test_clauck.py) to cover:
  - `cmd_broken` empty output
  - `cmd_broken` table output with stale markers and stable ordering proof
  - `cmd_discard` removal counts and missing-tombstone behavior
- Expanded [`tests/test_clauck_revive.py`](https://github.com/CoreyRDean/clauck/blob/refactor/tombstone-command-coverage/tests/test_clauck_revive.py) to cover:
  - DAG resume dispatch through `dag-runner.py --resume`
  - revive override contents on the DAG path
  - missing tombstone, stale tombstone, and missing-session-id error exits
- Kept the increment test-only: no runtime behavior changes, only stronger verification around the existing command contract.

Relevant intent: this advances clauck's inspectability and trust-via-proof contract by ensuring the user-facing recovery commands have observable, durable regression coverage.

Tests:
- `python3 -m unittest -v tests.test_clauck tests.test_clauck_revive`
- `python3 -m unittest discover tests -v`

Breaking changes: none.

## Additional notes
Trade-off: this does not add end-to-end subprocess execution for revive; it stays at the command boundary with `subprocess.Popen` mocked so the suite remains fast and isolated.

Deferred follow-up: issue #124 mentioned broader integration coverage for these command flows. This PR covers the command branches directly, but does not add real spawned-job fixtures beyond the existing `run-job.sh` resume-precedence test.

Remaining gap: if the repo later wants deeper end-to-end proof for revive side effects, that should be a separate increment rather than broadening this bounded test-only change.