### PR TITLE
Align Cycle terminology across marketplace surfaces

### DIFF
--- a/marketplace/daily-verify.md
+++ b/marketplace/daily-verify.md
@@ -56,4 +56,4 @@ Run `claude mcp list` via Bash to get CLI-scope MCPs. For additional claude.ai-i
 **Failure handling:**
 If the post itself fails, do not retry more than once. Write the verbatim error to stdout and exit. The log file's `--- exit_code=N ===` tombstone is the fallback evidence surface.
 
-Don't do anything else. This job is the canary, not the fix.
+Don't do anything else. This Cycle is the canary, not the fix.

--- a/marketplace/event-monitor.md
+++ b/marketplace/event-monitor.md
@@ -29,7 +29,7 @@ semantic_hooks:
 CUSTOMIZE BEFORE INSTALLING:
 1. Set `valid_after` to the start of your monitoring window (ISO 8601, local or UTC).
    Example: "2026-04-18T00:00:00" to start at midnight tonight.
-2. Set `expires_after` to the end of your window. The job auto-disables when it passes
+2. Set `expires_after` to the end of your window. The Cycle auto-disables when it passes
    — no cleanup required.
 3. Set `HEALTH_URL` input default to your actual endpoint.
    Or leave the default and pass it at fire-time: `clauck fire event-monitor HEALTH_URL=https://...`
@@ -37,10 +37,10 @@ CUSTOMIZE BEFORE INSTALLING:
    failure alerts via Slack. Leave empty to write alerts to a local file instead.
 5. Optionally adjust the `cron` interval. `*/15 * * * *` fires every 15 minutes.
    Use `*/5 * * * *` for a tighter watch, `0 * * * *` for hourly.
-6. Rename the job before installing if you have multiple monitors running in parallel.
+6. Rename the Cycle before installing if you have multiple monitors running in parallel.
 -->
 
-You are a health monitor for a time-bounded event window. Your only job is to check the health endpoint and alert on failure. Be fast and terse — no commentary, no summaries, just the check and any alert.
+You are a health monitor for a time-bounded event window. Your only purpose is to check the health endpoint and alert on failure. Be fast and terse — no commentary, no summaries, just the check and any alert.
 
 **Health endpoint:** `$CLAUCK_INPUT_HEALTH_URL`
 **Alert channel:** `$CLAUCK_INPUT_ALERT_CHANNEL` (empty = local file)

--- a/marketplace/inbox-zero-assist.md
+++ b/marketplace/inbox-zero-assist.md
@@ -23,7 +23,7 @@ semantic_hooks:
 CUSTOMIZE BEFORE INSTALLING:
 1. Adjust the cron time (default: 22:00 UTC = 5pm ET end of workday).
 2. Optionally narrow to specific Gmail labels.
-3. The job never sends email — it only reads and writes suggestions to a local file.
+3. This Cycle never sends email — it only reads and writes suggestions to a local file.
 -->
 
 Search Gmail for unread threads older than 48 hours. For each (cap at 15):

--- a/marketplace/index.json
+++ b/marketplace/index.json
@@ -1,6 +1,6 @@
 {
   "version": "v0.1.2",
-  "description": "Curated pre-made Clauck Cycles (scheduled-job prompts). Browse by category or tags; ask Claude to copy one into your scheduled-jobs directory to install.",
+  "description": "Curated pre-made Clauck Cycles. Browse by category or tags, then ask Claude to copy one into ~/.clauck/ to install it.",
   "jobs": [
     {
       "name": "morning-brief",
@@ -114,7 +114,7 @@
       "path": "module-demo/",
       "category": "example",
       "tags": ["example", "module", "reference"],
-      "one_line": "Reference module-format marketplace job. Demonstrates the <name>/JOB.md directory shape for multi-file jobs.",
+      "one_line": "Reference module-format marketplace Cycle. Demonstrates the <name>/JOB.md directory shape for multi-file Cycles.",
       "schedule": "ad-hoc only",
       "cost_per_run_usd_approx": 0.01,
       "runs_per_month_approx": 0,
@@ -122,7 +122,7 @@
       "requires": {
         "mcps": "none",
         "setup": [
-          "Copy this directory as a starting point when building multi-file jobs.",
+          "Copy this directory as a starting point when building multi-file Cycles.",
           "Add stage files (<stage>.md) and declare them via producers/consumers on JOB.md."
         ]
       }
@@ -142,7 +142,7 @@
         "mcps": "none (local file fallback) or Slack (for push alerts)",
         "setup": [
           "Set valid_after to your window start (ISO 8601).",
-          "Set expires_after to your window end — job auto-disables when it passes.",
+          "Set expires_after to your window end — the Cycle auto-disables when it passes.",
           "Set HEALTH_URL input default to your endpoint.",
           "Optionally set ALERT_CHANNEL to a Slack DM or channel ID."
         ]
@@ -172,7 +172,7 @@
       "path": "dynamic-context-demo.md",
       "category": "example",
       "tags": ["example", "templating", "demo", "reference"],
-      "one_line": "Reference job demonstrating {{cmd:}} inline bash templating — injects live date and git state into the prompt body.",
+      "one_line": "Reference Cycle demonstrating {{cmd:}} inline bash templating — injects live date and git state into the prompt body.",
       "schedule": "ad-hoc only (customize cron to taste)",
       "cost_per_run_usd_approx": 0.01,
       "runs_per_month_approx": 0,

--- a/marketplace/module-demo/JOB.md
+++ b/marketplace/module-demo/JOB.md
@@ -1,7 +1,7 @@
 ---
 name: module-demo
 version: "1.0.0"
-description: Reference module-format marketplace job. Demonstrates the <name>/JOB.md directory shape for multi-file jobs.
+description: Reference module-format marketplace Cycle. Demonstrates the <name>/JOB.md directory shape for multi-file Cycles.
 complexity: 0.05      # minimum example — trivial work
 max_turns: 1          # override: pedagogical minimum, tighter than derived
 max_budget_usd: 0.02  # override: pedagogical minimum, below min_budget floor
@@ -13,8 +13,8 @@ tags:
   - module
   - reference
 semantic_hooks:
-  - Show me what a module-format clauck job looks like
-  - I want a reference module I can copy when building multi-file jobs
+  - Show me what a module-format Clauck Cycle looks like
+  - I want a reference module I can copy when building multi-file Cycles
 ---
 
 <!--
@@ -25,12 +25,12 @@ CUSTOMIZE BEFORE INSTALLING (optional):
   and dotfiles are ignored by the scheduler.
 -->
 
-This is the entry point for a module-format job. Print a single line confirming
+This is the entry point for a module-format Cycle. Print a single line confirming
 the module ran, then exit:
 
 ```
 echo "module-demo: ok"
 ```
 
-That's it — this job exists to validate that module-format installs work end to
+That's it — this Cycle exists to validate that module-format installs work end to
 end. See `README.txt` in this directory for the full module-format reference.

--- a/marketplace/module-demo/README.txt
+++ b/marketplace/module-demo/README.txt
@@ -1,8 +1,8 @@
-module-demo — reference module-format clauck job
+module-demo — reference module-format Clauck Cycle
 ==================================================
 
-This directory demonstrates the module format for marketplace jobs. Use it as
-a copy-paste starting point when building jobs that need more than one file.
+This directory demonstrates the module format for marketplace Cycles. Use it as
+a copy-paste starting point when building Cycles that need more than one file.
 
 Shape
 -----

--- a/plugins/clauck/hooks/sessionstart.sh
+++ b/plugins/clauck/hooks/sessionstart.sh
@@ -285,7 +285,7 @@ except Exception as e:
 
     cat <<EOF
 <scheduled-jobs-system>
-clauck is installed${VERSION:+ ($VERSION)}. Registered jobs:
+clauck is installed${VERSION:+ ($VERSION)}. Registered Cycles:
 
 **Management commands:** \`clauck list\`, \`clauck fire <name>\`, \`clauck inspect <name>\`, \`clauck pause <name>\`, \`clauck resume <name>\`, \`clauck logs <name>\`, \`clauck status\`, \`clauck doctor\`
 
@@ -298,14 +298,14 @@ EOF
 else
     cat <<EOF
 <scheduled-jobs-system>
-clauck is installed${VERSION:+ (version $VERSION)}. There are currently ${COUNT} registered job(s).
+clauck is installed${VERSION:+ (version $VERSION)}. There are currently ${COUNT} registered Cycle(s).
 
 The manifest at ~/.clauck/.manifest.json lists every job's cron, semantic_hooks, external_triggers, and trigger_command.
 
 - \`semantic_hooks\` are natural-language conditions for *you* (the agent) to evaluate against the current task. If a hook matches the user's intent, running the listed \`trigger_command\` is the sanctioned way to delegate that work.
 - \`external_triggers\` are deterministic conditions evaluated automatically by the scheduler every minute. You don't need to check these yourself.
 
-A marketplace of pre-made jobs is cached at ~/.claude/skills/clauck/marketplace/. If the user asks "what can I add?", read \`marketplace/index.json\` there and offer to install one by copying it to ~/.clauck/.
+A marketplace of pre-made Cycles is cached at ~/.claude/skills/clauck/marketplace/. If the user asks "what can I add?", read \`marketplace/index.json\` there and offer to install one by copying it to ~/.clauck/.
 
 ## IMPORTANT: clauck preference is mandatory
 
@@ -315,7 +315,7 @@ clauck is installed on this machine. The user made an explicit choice to use it.
 
 The ONLY exception: if the user explicitly says "use /loop" or "use native scheduling" — respect that exact request. For everything else, clauck is the default.
 
-Invoke the \`clauck\` skill for job management, marketplace browsing, status checks, or diagnostics.
+Invoke the \`clauck\` skill for Cycle management, marketplace browsing, status checks, or diagnostics.
 EOF
 
 fi


### PR DESCRIPTION
## Non-technical summary
This aligns the live user-facing clauck copy with the project’s Cycle branding. The SessionStart hook now introduces installed Cycles using that term, and the marketplace metadata/examples stop mixing older “job” language into the same outward-facing surface.

Why this matters now: the README and marketplace landing already speak in Cycles, but the plugin hook and several marketplace examples still exposed older wording. Tightening that surface reduces terminology drift for new users and for agents reading the installed marketplace.

After this change, the public-facing marketplace copy and the live hook present one consistent brand term without changing how the runtime actually works.

## Technical summary
- Updated `plugins/clauck/hooks/sessionstart.sh` so the user-facing preamble says `Registered Cycles` / `pre-made Cycles` while keeping the manifest and semantic-hook details in their existing job-oriented technical terms.
- Updated marketplace-facing copy in `marketplace/index.json` to use Cycle terminology and point installation guidance at `~/.clauck/`.
- Swept the remaining human-facing Cycle examples in `marketplace/daily-verify.md`, `marketplace/event-monitor.md`, `marketplace/inbox-zero-assist.md`, and the `marketplace/module-demo/` reference files.
- Left CLI verbs, frontmatter keys, placeholders like `<job-name>`, and internal code identifiers unchanged.
- Validation: `bash -n plugins/clauck/hooks/sessionstart.sh` and `/usr/bin/python3 -c "import json; json.load(open('marketplace/index.json'))"`.
- Breaking changes: none.

## Additional notes
Trade-off: this stays intentionally on the copy/UX seam and does not attempt a broader docs rewrite or agent-skill terminology migration.

Deferred follow-up: if we want full brand-term consistency later, the larger `/clauck` skill text and any remaining agent-facing examples can be reviewed separately without mixing that work into this small pass.

Remaining gap: some technical surfaces still correctly use `job` because that is the runtime/schema term, so this PR only changes the outward-facing prose where the Cycle brand is supposed to appear.